### PR TITLE
Fix GCC build

### DIFF
--- a/dispenso/future.h
+++ b/dispenso/future.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <functional>
+#include <vector>
 
 #include <dispenso/detail/future_impl.h>
 #include <dispenso/detail/result_of.h>

--- a/dispenso/platform.h
+++ b/dispenso/platform.h
@@ -77,8 +77,12 @@ constexpr size_t kCacheLineSize = 64;
 #define DISPENSO_DISABLE_WARNING_PUSH DO_PRAGMA(GCC diagnostic push)
 #define DISPENSO_DISABLE_WARNING_POP DO_PRAGMA(GCC diagnostic pop)
 #define DISPENSO_DISABLE_WARNING(warningName) DO_PRAGMA(GCC diagnostic ignored #warningName)
+#if defined(__GNUC__)
+#define DISPENSO_DISABLE_WARNING_ZERO_VARIADIC_MACRO_ARGUMENTS
+#else
 #define DISPENSO_DISABLE_WARNING_ZERO_VARIADIC_MACRO_ARGUMENTS \
   DISPENSO_DISABLE_WARNING(-Wgnu-zero-variadic-macro-arguments)
+#endif
 #elif defined(_MSC_VER)
 #define DISPENSO_DISABLE_WARNING_PUSH __pragma(warning(push))
 #define DISPENSO_DISABLE_WARNING_POP __pragma(warning(pop))


### PR DESCRIPTION
This fixes some build errors I encountered while setting up CircleCI automation.

- future.h should #include &lt;vector&gt;
- GCC doesn't have -Wgnu-zero-variadic-macro-arguments