### PR TITLE
Add CMake install target + CMake dispenso target exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,19 @@
 cmake_minimum_required(VERSION 3.12)
 project(
   Dispenso
-  VERSION 0.1.0
+  VERSION 1.0.0
   DESCRIPTION "Dispenso is a library for working with sets of parallel tasks"
   LANGUAGES CXX)
+
+if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+  set(DISPENSO_STANDALONE TRUE)
+else()
+  set(DISPENSO_STANDALONE FALSE)
+endif()
+
+if (DISPENSO_STANDALONE)
+  include(GNUInstallDirs)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,32 @@ Install Build Tools for Visual Studio. All commands should be run from the Devel
 1. `cmake PATH_TO_DISPENSO_ROOT`
 1. `cmake --build . --config Release`
 
+## Install dispenso
+
+Once built, the library can be installed by building the "install" target.
+Typically on Linux and MacOS, this is done with
+
+`make install`
+
+On Windows (and works on any platfrom), instead do
+
+`cmake --build . --target install`
+
+## Use an installed dispenso
+
+Once installed, a downstream CMake project can be pointed to it by using
+`CMAKE_PREFIX_PATH` or `Dispenso_DIR`, either as an environment variable or
+CMake variable. All that is required to use the library is link the imported
+CMake target `Dispenso::dispenso`, which might look like
+
+```cmake
+find_pacakge(Dispenso REQUIRED)
+target_link_libraries(myDispensoApp Dispenso::dispenso)
+```
+
+This brings in all required include paths, library files to link, and any other
+properties to the `myDispensoApp` target (your library or application).
+
 <div id='testing'/>
 
 # Building and running dispenso tests

--- a/cmake/DispensoConfig.cmake.in
+++ b/cmake/DispensoConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@_Exports.cmake")
+
+check_required_components("@PROJECT_NAME@")

--- a/cmake/DispensoConfig.cmake.in
+++ b/cmake/DispensoConfig.cmake.in
@@ -1,5 +1,9 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@_Exports.cmake")
 
 check_required_components("@PROJECT_NAME@")

--- a/dispenso/CMakeLists.txt
+++ b/dispenso/CMakeLists.txt
@@ -28,10 +28,13 @@ PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dispenso/third-party/moodycamel>
 )
 
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+target_link_libraries(dispenso PUBLIC Threads::Threads)
+
 if(WIN32)
-  target_link_libraries(dispenso Synchronization)
-else()
-  target_link_libraries(dispenso pthread)
+  target_link_libraries(dispenso PUBLIC Synchronization)
 endif()
 
 target_compile_features(dispenso PUBLIC cxx_std_14)

--- a/dispenso/CMakeLists.txt
+++ b/dispenso/CMakeLists.txt
@@ -19,7 +19,14 @@ target_compile_options(dispenso PRIVATE
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic -Wconversion -Wno-sign-conversion -Werror>
   )
 
-target_include_directories(dispenso PUBLIC .. third-party/moodycamel "${PROJECT_BINARY_DIR}")
+target_include_directories(dispenso
+PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/..>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/third-party/moodycamel>
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/dispenso/third-party/moodycamel>
+)
 
 if(WIN32)
   target_link_libraries(dispenso Synchronization)
@@ -28,3 +35,66 @@ else()
 endif()
 
 target_compile_features(dispenso PUBLIC cxx_std_14)
+
+if (NOT DISPENSO_STANDALONE)
+  return()
+endif()
+
+## Install library ##
+
+set_target_properties(dispenso
+    PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION ${PROJECT_VERSION_MAJOR})
+
+install(TARGETS dispenso
+  EXPORT ${PROJECT_NAME}_Exports
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    NAMELINK_SKIP
+  # on Windows put the dlls into bin
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  # ... and the import lib into the devel package
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(EXPORT ${PROJECT_NAME}_Exports
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+  NAMESPACE Dispenso::
+)
+
+install(TARGETS dispenso
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    NAMELINK_ONLY
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+## Install headers ##
+
+install(DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING
+    PATTERN *.h
+)
+
+## Generate and install CMake target exports ##
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}Config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+INSTALL_DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+)
+
+write_basic_package_version_file(
+  "${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+DESTINATION
+  ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}-${PROJECT_VERSION}
+)


### PR DESCRIPTION
# PR Details

This PR adds an `install` target for the main dispenso library, including CMake target exports.

## Description

The following changes were made:

- The root level `project()` version was updated to `1.0.0`, which gets used in the CMake exports
- The `install` target is only created when doing a stand alone build of dispenso (i.e. not under `add_subdirectory()`), which is detected with checking if `CMAKE_SOURCE_DIR` and `CMAKE_CURRENT_SOURCE_DIR` are equal.
- The built-in CMake `Threads` module was used for more robust consumption of `pthreads` downstream.
- Updated the README with a brief description about installing and linking downstream with CMake.

## Related Issue

Did not create an issue.

## Motivation and Context

This makes dispenso packageable and installable.

## Test Plan

No C++ code was changed. The existing build process is unchanged.

## Types of changes

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] I have run clang-format.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed, including in ASAN and TSAN modes (if available on your platform).
