### PR TITLE
Beef up internal warnings to match our OSS CircleCI warning levels

### DIFF
--- a/dispenso/thread_pool.h
+++ b/dispenso/thread_pool.h
@@ -94,7 +94,9 @@ class alignas(kCacheLineSize) ThreadPool {
       const std::chrono::duration<Rep, Period>& sleepDuration =
           std::chrono::microseconds(kDefaultSleepLenUs)) {
     setSignalingWake(
-        enable, std::chrono::duration_cast<std::chrono::microseconds>(sleepDuration).count());
+        enable,
+        static_cast<uint32_t>(
+            std::chrono::duration_cast<std::chrono::microseconds>(sleepDuration).count()));
   }
 
   /**

--- a/tests/future_test.cpp
+++ b/tests/future_test.cpp
@@ -697,10 +697,7 @@ TEST(Future, SimpleExceptionsReference) {
 TEST(Future, SimpleExceptionsVoid) {
   bool handledException = false;
   int val = 333;
-  auto voidFuture = dispenso::async([&val]() -> int& {
-    throw(std::logic_error("oops"));
-    val = 222;
-  });
+  auto voidFuture = dispenso::async([]() { throw(std::logic_error("oops")); });
 
   try {
     voidFuture.get();

--- a/tests/task_set_test.cpp
+++ b/tests/task_set_test.cpp
@@ -237,15 +237,9 @@ TEST(TaskSet, Exception) {
   dispenso::ThreadPool pool(10);
   dispenso::TaskSet tasks(pool);
 
-  int data;
-  int* datap = &data;
+  int data = 3;
 
-  tasks.schedule(
-      [datap]() {
-        throw std::logic_error("oops");
-        *datap = 5;
-      },
-      dispenso::ForceQueuingTag());
+  tasks.schedule([]() { throw std::logic_error("oops"); }, dispenso::ForceQueuingTag());
 
   bool caught = false;
   try {
@@ -262,15 +256,9 @@ TEST(ConcurrentTaskSet, Exception) {
   dispenso::ThreadPool pool(10);
   dispenso::ConcurrentTaskSet tasks(pool);
 
-  int data;
-  int* datap = &data;
+  int data = 3;
 
-  tasks.schedule(
-      [datap]() {
-        throw std::logic_error("oops");
-        *datap = 5;
-      },
-      dispenso::ForceQueuingTag());
+  tasks.schedule([]() { throw std::logic_error("oops"); }, dispenso::ForceQueuingTag());
 
   bool caught = false;
   try {
@@ -287,13 +275,9 @@ TEST(TaskSet, ExceptionNoForceQueuing) {
   dispenso::ThreadPool pool(10);
   dispenso::TaskSet tasks(pool);
 
-  int data;
-  int* datap = &data;
+  int data = 3;
 
-  tasks.schedule([datap]() {
-    throw std::logic_error("oops");
-    *datap = 5;
-  });
+  tasks.schedule([]() { throw std::logic_error("oops"); });
 
   bool caught = false;
   try {
@@ -310,13 +294,9 @@ TEST(ConcurrentTaskSet, ExceptionNoForceQueuing) {
   dispenso::ThreadPool pool(10);
   dispenso::ConcurrentTaskSet tasks(pool);
 
-  int data;
-  int* datap = &data;
+  int data = 3;
 
-  tasks.schedule([datap]() {
-    throw std::logic_error("oops");
-    *datap = 5;
-  });
+  tasks.schedule([]() { throw std::logic_error("oops"); });
 
   bool caught = false;
   try {
@@ -334,14 +314,8 @@ TEST(TaskSet, ExceptionTryWait) {
   dispenso::TaskSet tasks(pool);
 
   int data = 32767;
-  int* datap = &data;
 
-  tasks.schedule(
-      [datap]() {
-        throw std::logic_error("oops");
-        *datap = 5;
-      },
-      dispenso::ForceQueuingTag());
+  tasks.schedule([]() { throw std::logic_error("oops"); }, dispenso::ForceQueuingTag());
 
   bool caught = false;
   try {
@@ -359,15 +333,9 @@ TEST(ConcurrentTaskSet, ExceptionTryWait) {
   dispenso::ThreadPool pool(10);
   dispenso::ConcurrentTaskSet tasks(pool);
 
-  int data;
-  int* datap = &data;
+  int data = 3;
 
-  tasks.schedule(
-      [datap]() {
-        throw std::logic_error("oops");
-        *datap = 5;
-      },
-      dispenso::ForceQueuingTag());
+  tasks.schedule([]() { throw std::logic_error("oops"); }, dispenso::ForceQueuingTag());
 
   bool caught = false;
   try {
@@ -385,13 +353,9 @@ TEST(TaskSet, ExceptionNoForceQueuingTryWait) {
   dispenso::ThreadPool pool(10);
   dispenso::TaskSet tasks(pool);
 
-  int data;
-  int* datap = &data;
+  int data = 3;
 
-  tasks.schedule([datap]() {
-    throw std::logic_error("oops");
-    *datap = 5;
-  });
+  tasks.schedule([]() { throw std::logic_error("oops"); });
 
   bool caught = false;
   try {
@@ -409,13 +373,9 @@ TEST(ConcurrentTaskSet, ExceptionNoForceQueuingTryWait) {
   dispenso::ThreadPool pool(10);
   dispenso::ConcurrentTaskSet tasks(pool);
 
-  int data;
-  int* datap = &data;
+  int data = 3;
 
-  tasks.schedule([datap]() {
-    throw std::logic_error("oops");
-    *datap = 5;
-  });
+  tasks.schedule([]() { throw std::logic_error("oops"); });
 
   bool caught = false;
   try {


### PR DESCRIPTION
Summary:
We want to catch future compiler warning issues at working time or internal CI time, rather than having code land and then we catch those issues in CircleCI, requiring another fix round trip.  This change will help facilitate that.
  Additionally, remove a few old workarounds for compiler warnings in when testing exceptions.

Differential Revision: D38914306

