### PR TITLE
bump version in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 cmake_minimum_required(VERSION 3.12)
 project(
   Dispenso
-  VERSION 1.0.0
+  VERSION 1.1.0
   DESCRIPTION "Dispenso is a library for working with sets of parallel tasks"
   LANGUAGES CXX)
 


### PR DESCRIPTION
Summary: Dispenso 1.1.0 is tagged in GitHub, but CMakeLists still declare 1.0.0

Differential Revision: D41654599

