### PR TITLE
platform.h: add cpuRelax for PowerPC and ARM

### DIFF
--- a/dispenso/platform.h
+++ b/dispenso/platform.h
@@ -163,8 +163,22 @@ inline constexpr uintptr_t alignToCacheLine(uintptr_t val) {
 inline void cpuRelax() {
   asm volatile("pause" ::: "memory");
 }
+#elif defined __arm64__ || defined __aarch64__
+inline void cpuRelax() {
+  asm volatile("yield" ::: "memory");
+}
+#elif defined __powerpc__ || defined __POWERPC__
+  #if defined __APPLE__
+  inline void cpuRelax() {
+    asm volatile("or r27,r27,r27" ::: "memory");
+  }
+  #else
+  inline void cpuRelax() {
+    asm volatile("or 27,27,27" ::: "memory");
+  }
+  #endif
 #else
-// TODO: provide reasonable relax on non-x86
+// TODO: provide reasonable relax on other archs.
 inline void cpuRelax() {}
 #endif // x86-arch
 


### PR DESCRIPTION
# PR Details

I have noticed that the header lacks `cpuRelax` for non-x86 archs. The PR adds support for arm64 and ppc/ppc64.

## Description

Provided code is used elsewhere, for example in Boost. So the proposed change is trivial.
https://www.boost.org/doc/libs/1_84_0/boost/fiber/detail/cpu_relax.hpp
Similar one used in `mimalloc`: https://github.com/microsoft/mimalloc/blob/master/include/mimalloc/atomic.h

## Related Issue

<!--- Please link to the issue here: -->

## Motivation and Context

The change partly addresses a TODO comment in `platform.h` (partly in a sense of adding support for additional architectures but not for every possible one).

## Test Plan

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have run clang-format.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed, including in ASAN and TSAN modes (if available on your platform).
