### PR TITLE
Disable installing gtest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 cmake_minimum_required(VERSION 3.14)
 
 ### TODO(bbudge): Set up testing with github actions
@@ -13,6 +18,7 @@ FetchContent_Declare(
 
 # For Windows, Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(GoogleTest)
 include(GoogleTest)
 


### PR DESCRIPTION
Summary:
Otherwise, gtest and gmock are installed with Dispenso:

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=959974&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823&l=2701

Differential Revision: D58911890
