### PR TITLE
remove template specification

### DIFF
--- a/dispenso/graph.h
+++ b/dispenso/graph.h
@@ -486,7 +486,7 @@ class DISPENSO_DLL_ACCESS SubgraphT {
 
   static constexpr size_t kNodeSizeP2 = detail::nextPow2(sizeof(NodeType));
 
-  explicit SubgraphT<N>(GraphT<N>* graph) : graph_(graph), nodes_(), allocator_(getAllocator()) {}
+  explicit SubgraphT(GraphT<N>* graph) : graph_(graph), nodes_(), allocator_(getAllocator()) {}
 
   inline void removeNodeFromBiPropSet(Node* /* node */) {}
   void removeNodeFromBiPropSet(BiPropNode* node) {
@@ -527,7 +527,7 @@ class DISPENSO_DLL_ACCESS GraphT {
   /**
    * Create empty graph.
    **/
-  GraphT<N>() {
+  GraphT() {
     subgraphs_.push_back(SubgraphType(this));
   }
   /**


### PR DESCRIPTION
# PR Details

fix compilation error with gcc 14 (Fedora 40)

## Description

Remove template specification to avoid error `error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]`


## Related Issue

#35 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Test Plan

I've compiled the code with  the g++ from ubuntu 20.04, 22.04 and 24.04 docker images  and g++  from Fedora 40 and executed the tests with success except for the test Priorty.PriorityGetsCycles

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change
- [ ] Refactoring
- [ ] Dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have run clang-format.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed, including in ASAN and TSAN modes (if available on your platform).
