### PR TITLE
Add C++20 concept constraints for better error messages

### DIFF
--- a/dispenso/for_each.h
+++ b/dispenso/for_each.h
@@ -22,6 +22,17 @@
 
 namespace dispenso {
 
+#if DISPENSO_HAS_CONCEPTS
+/**
+ * @concept ForEachFunc
+ * @brief A callable suitable for for_each operations.
+ *
+ * The callable must be invocable with a reference to the iterator's value type.
+ **/
+template <typename F, typename Iter>
+concept ForEachFunc = std::invocable<F, decltype(*std::declval<Iter>())>;
+#endif // DISPENSO_HAS_CONCEPTS
+
 /**
  * A set of options to control for_each
  **/
@@ -55,6 +66,7 @@ struct ForEachOptions {
  * @param options See ForEachOptions for details.
  **/
 template <typename TaskSetT, typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each_n(TaskSetT& tasks, Iter start, size_t n, F&& f, ForEachOptions options = {}) {
   // TODO(bbudge): With options.maxThreads, we might want to allow a small fanout factor in
   // recursive case?
@@ -144,6 +156,7 @@ void for_each_n(TaskSetT& tasks, Iter start, size_t n, F&& f, ForEachOptions opt
  * always wait, and therefore options.wait is ignored.
  **/
 template <typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each_n(Iter start, size_t n, F&& f, ForEachOptions options = {}) {
   TaskSet taskSet(globalThreadPool());
   options.wait = true;
@@ -162,6 +175,7 @@ void for_each_n(Iter start, size_t n, F&& f, ForEachOptions options = {}) {
  * @param options See ForEachOptions for details.
  **/
 template <typename TaskSetT, typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each(TaskSetT& tasks, Iter start, Iter end, F&& f, ForEachOptions options = {}) {
   for_each_n(tasks, start, std::distance(start, end), std::forward<F>(f), options);
 }
@@ -178,6 +192,7 @@ void for_each(TaskSetT& tasks, Iter start, Iter end, F&& f, ForEachOptions optio
  * always wait, and therefore options.wait is ignored.
  **/
 template <typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each(Iter start, Iter end, F&& f, ForEachOptions options = {}) {
   for_each_n(start, std::distance(start, end), std::forward<F>(f), options);
 }

--- a/dispenso/future.h
+++ b/dispenso/future.h
@@ -351,6 +351,7 @@ class Future<void> : detail::FutureBase<void> {
   Future(const Future& f) noexcept : Base(f) {}
   Future(const Base& f) noexcept : Base(f) {}
   template <typename F, typename Schedulable>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   Future(
       F&& f,
       Schedulable& schedulable,

--- a/dispenso/graph.h
+++ b/dispenso/graph.h
@@ -20,9 +20,11 @@
 #include <type_traits>
 #include <vector>
 
+#include <dispenso/once_function.h>
 #include <dispenso/platform.h>
 #include <dispenso/pool_allocator.h>
 #include <dispenso/small_buffer_allocator.h>
+
 /*
 Terminology
 --------------------------------------------------------------------------------
@@ -431,6 +433,7 @@ class DISPENSO_DLL_ACCESS SubgraphT {
    * @return reference to the created node.
    **/
   template <class T>
+  DISPENSO_REQUIRES(OnceCallableFunc<T>)
   N& addNode(T&& f) {
     nodes_.push_back(new (allocator_->alloc()) NodeType(std::forward<T>(f)));
     return *nodes_.back();
@@ -551,6 +554,7 @@ class DISPENSO_DLL_ACCESS GraphT {
    * @param f A functor with signature void().
    **/
   template <class T>
+  DISPENSO_REQUIRES(OnceCallableFunc<T>)
   N& addNode(T&& f) {
     return subgraphs_[0].addNode(std::forward<T>(f));
   }

--- a/dispenso/once_function.h
+++ b/dispenso/once_function.h
@@ -17,8 +17,23 @@
 #include <utility>
 
 #include <dispenso/detail/once_callable_impl.h>
+#include <dispenso/platform.h>
 
 namespace dispenso {
+
+#if DISPENSO_HAS_CONCEPTS
+/**
+ * @concept OnceCallableFunc
+ * @brief A callable suitable for wrapping in OnceFunction or scheduling as a task.
+ *
+ * The callable must be invocable with no arguments. The return value (if any) is discarded.
+ * This is the fundamental requirement for functors passed to OnceFunction,
+ * ThreadPool::schedule, TaskSet::schedule, and similar scheduling interfaces.
+ **/
+template <typename F>
+concept OnceCallableFunc = std::invocable<F>;
+#endif // DISPENSO_HAS_CONCEPTS
+
 namespace detail {
 template <typename Result>
 class FutureBase;
@@ -55,6 +70,7 @@ class OnceFunction {
    * overhead for double type erasure.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   OnceFunction(F&& f) : onceCallable_(detail::createOnceCallable(std::forward<F>(f))) {}
 
   OnceFunction(const OnceFunction& other) = delete;

--- a/dispenso/parallel_for.h
+++ b/dispenso/parallel_for.h
@@ -23,6 +23,44 @@
 
 namespace dispenso {
 
+#if DISPENSO_HAS_CONCEPTS
+/**
+ * @concept ParallelForRangeFunc
+ * @brief A callable suitable for chunked parallel_for with (begin, end) signature.
+ *
+ * The callable must be invocable with two integer arguments representing the chunk range.
+ **/
+template <typename F, typename IntegerT>
+concept ParallelForRangeFunc = std::invocable<F, IntegerT, IntegerT>;
+
+/**
+ * @concept ParallelForIndexFunc
+ * @brief A callable suitable for element-wise parallel_for with single index signature.
+ *
+ * The callable must be invocable with a single integer argument representing the element index.
+ **/
+template <typename F, typename IntegerT>
+concept ParallelForIndexFunc = std::invocable<F, IntegerT>;
+
+/**
+ * @concept ParallelForStateRangeFunc
+ * @brief A callable suitable for stateful chunked parallel_for.
+ *
+ * The callable must be invocable with (State&, begin, end) arguments.
+ **/
+template <typename F, typename StateRef, typename IntegerT>
+concept ParallelForStateRangeFunc = std::invocable<F, StateRef, IntegerT, IntegerT>;
+
+/**
+ * @concept ParallelForStateIndexFunc
+ * @brief A callable suitable for stateful element-wise parallel_for.
+ *
+ * The callable must be invocable with (State&, index) arguments.
+ **/
+template <typename F, typename StateRef, typename IntegerT>
+concept ParallelForStateIndexFunc = std::invocable<F, StateRef, IntegerT>;
+#endif // DISPENSO_HAS_CONCEPTS
+
 /**
  * Chunking strategy.  Typically if the cost of each loop iteration is roughly constant, kStatic
  * load balancing is preferred.  Additionally, when making a non-waiting parallel_for call in
@@ -513,6 +551,7 @@ void parallel_for(
  * @param options See ParForOptions for details.
  **/
 template <typename TaskSetT, typename IntegerT, typename F>
+DISPENSO_REQUIRES(ParallelForRangeFunc<F, IntegerT>)
 void parallel_for(
     TaskSetT& taskSet,
     const ChunkedRange<IntegerT>& range,
@@ -538,6 +577,7 @@ void parallel_for(
  *to true.
  **/
 template <typename IntegerT, typename F>
+DISPENSO_REQUIRES(ParallelForRangeFunc<F, IntegerT>)
 void parallel_for(const ChunkedRange<IntegerT>& range, F&& f, ParForOptions options = {}) {
   TaskSet taskSet(globalThreadPool());
   options.wait = true;

--- a/dispenso/platform.h
+++ b/dispenso/platform.h
@@ -26,6 +26,34 @@ namespace dispenso {
 #define DISPENSO_MINOR_VERSION 4
 #define DISPENSO_PATCH_VERSION 1
 
+// C++20 concepts support detection
+#if __cplusplus >= 202002L && defined(__cpp_concepts) && __cpp_concepts >= 201907L
+#define DISPENSO_HAS_CONCEPTS 1
+#include <concepts>
+#else
+#define DISPENSO_HAS_CONCEPTS 0
+#endif
+
+/**
+ * @def DISPENSO_REQUIRES
+ * @brief Macro for conditionally applying C++20 concept constraints.
+ *
+ * On C++20 with concepts support, this expands to a requires clause.
+ * On C++14/17, this expands to nothing, maintaining backward compatibility.
+ *
+ * Example usage:
+ * @code
+ * template <typename F>
+ * DISPENSO_REQUIRES(std::invocable<F>)
+ * void schedule(F&& f);
+ * @endcode
+ **/
+#if DISPENSO_HAS_CONCEPTS
+#define DISPENSO_REQUIRES(...) requires(__VA_ARGS__)
+#else
+#define DISPENSO_REQUIRES(...)
+#endif
+
 #if defined(DISPENSO_SHARED_LIB)
 #if defined _WIN32
 

--- a/dispenso/schedulable.h
+++ b/dispenso/schedulable.h
@@ -35,6 +35,7 @@ class ImmediateInvoker {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f) const {
     f();
   }
@@ -45,6 +46,7 @@ class ImmediateInvoker {
    *
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag) const {
     f();
   }
@@ -67,6 +69,7 @@ class NewThreadInvoker {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f) const {
     schedule(std::forward<F>(f), ForceQueuingTag());
   }
@@ -78,6 +81,7 @@ class NewThreadInvoker {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag) const {
     std::thread thread([f = std::move(f)]() { f(); });
     thread.detach();

--- a/dispenso/task_set.h
+++ b/dispenso/task_set.h
@@ -72,6 +72,7 @@ class TaskSet : public TaskSetBase {
    * in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f) {
     if (DISPENSO_EXPECT(canceled(), false)) {
       return;
@@ -95,6 +96,7 @@ class TaskSet : public TaskSetBase {
    * from the set is rethrown in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag fq) {
     pool_.schedule(token_, packageTask(std::forward<F>(f)), fq);
   }
@@ -211,6 +213,7 @@ class ConcurrentTaskSet : public TaskSetBase {
    * in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, bool skipRecheck = false) {
     if (outstandingTaskCount_.load(std::memory_order_relaxed) > taskSetLoadFactor_ &&
         DISPENSO_EXPECT(!canceled(), true)) {
@@ -234,6 +237,7 @@ class ConcurrentTaskSet : public TaskSetBase {
    * from the set is rethrown in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag fq) {
     pool_.schedule(packageTask(std::forward<F>(f)), fq);
   }

--- a/dispenso/thread_pool.h
+++ b/dispenso/thread_pool.h
@@ -141,6 +141,7 @@ class alignas(kCacheLineSize) ThreadPool {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f);
 
   /**
@@ -152,6 +153,7 @@ class alignas(kCacheLineSize) ThreadPool {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag);
 
   /**
@@ -270,6 +272,7 @@ DISPENSO_DLL_ACCESS void resizeGlobalThreadPool(size_t numThreads);
 // ----------------------------- Implementation details -------------------------------------
 
 template <typename F>
+DISPENSO_REQUIRES(OnceCallableFunc<F>)
 inline void ThreadPool::schedule(F&& f) {
   ssize_t curWork = workRemaining_.load(std::memory_order_relaxed);
   ssize_t quickLoadFactor = numThreads_.load(std::memory_order_relaxed);
@@ -283,6 +286,7 @@ inline void ThreadPool::schedule(F&& f) {
 }
 
 template <typename F>
+DISPENSO_REQUIRES(OnceCallableFunc<F>)
 inline void ThreadPool::schedule(F&& f, ForceQueuingTag) {
   if (auto* token =
           static_cast<moodycamel::ProducerToken*>(detail::PerPoolPerThreadInfo::producer(this))) {


### PR DESCRIPTION
Summary:
Add optional C++20 concept constraints to dispenso's template APIs. When
compiled with C++20, users get clearer error messages when passing invalid
types to template functions. On C++14/17, the concepts are disabled and
the library compiles exactly as before.

Infrastructure added to platform.h:
- DISPENSO_HAS_CONCEPTS: Feature detection macro
- DISPENSO_REQUIRES: Macro that expands to requires() on C++20, nothing otherwise

Shared concept in once_function.h:
- OnceCallableFunc: void-returning invocable, used by all scheduling APIs

Local concepts in parallel_for.h:
- ParallelForRangeFunc, ParallelForIndexFunc (for index-based parallel_for)

Local concept in for_each.h:
- ForEachFunc (for iterator-based for_each)

Applied DISPENSO_REQUIRES to:
- OnceFunction constructor
- ThreadPool::schedule (4 overloads)
- TaskSet::schedule (2 overloads)
- ConcurrentTaskSet::schedule (2 overloads)
- ImmediateInvoker::schedule (2 overloads)
- NewThreadInvoker::schedule (2 overloads)
- SubgraphT::addNode and GraphT::addNode
- Future<void> constructor
- parallel_for ChunkedRange overloads (2)
- for_each and for_each_n (4 overloads)

Differential Revision: D91712601
