### PR TITLE
Make timed_task tests reliable for CI

### DIFF
--- a/dispenso/concurrent_object_arena.h
+++ b/dispenso/concurrent_object_arena.h
@@ -43,7 +43,7 @@ namespace dispenso {
  * arrays, with additional bookkeeping. The size of arrays is always power of
  * two (to optimize indexed access)
  * <pre>
- *  buffers  |<────     bufferSize      ───>|
+ *  buffers  |&lt;────     bufferSize      ────&gt;|
  *    ┌─┐    ┌──────────────────────────────┐
  *    │*├───>│                              │
  *    ├─┤    ├──────────────────────────────┤
@@ -153,7 +153,7 @@ struct ConcurrentObjectArena {
    * This function is thread safe and never invalidates pointers or
    * references to the rest of the elements. It is lock-free if new elements
    * can be placed in current buffer. It locks if it allocates a new buffer.
-   * @param delta New size of the container will be <code>delta<\code> elements bigger.
+   * @param delta New size of the container will be <code>delta</code> elements bigger.
    * @return index of the first element of the allocated group.
    **/
   Index grow_by(const Index delta) {

--- a/dispenso/detail/future_impl.h
+++ b/dispenso/detail/future_impl.h
@@ -225,7 +225,7 @@ class FutureImplBase : private FutureImplResultMember<Result>, public OnceCallab
 
     ThenChain* scheduleDestroyAndGetNext() {
       invoke(impl, schedulable);
-      constexpr size_t kImplSize = nextPow2(sizeof(this));
+      constexpr size_t kImplSize = static_cast<size_t>(nextPow2(sizeof(this)));
       auto* ret = this->next;
       deallocSmallBuffer<kImplSize>(this);
       return ret;
@@ -275,7 +275,7 @@ class FutureImplBase : private FutureImplResultMember<Result>, public OnceCallab
       return;
     }
 
-    constexpr size_t kImplSize = nextPow2(sizeof(ThenChain));
+    constexpr size_t kImplSize = static_cast<size_t>(nextPow2(sizeof(ThenChain)));
     auto* buffer = allocSmallBuffer<kImplSize>();
     ThenChain* link = reinterpret_cast<ThenChain*>(buffer);
     link->impl = impl;
@@ -391,7 +391,7 @@ template <typename Result, typename F>
 inline FutureImplBase<Result>*
 createFutureImpl(F&& f, bool allowInline, std::atomic<ssize_t>* taskSetCounter) {
   using FNoRef = typename std::remove_reference<F>::type;
-  constexpr size_t kImplSize = nextPow2(sizeof(FutureImplSmall<16, FNoRef, Result>));
+  constexpr size_t kImplSize = static_cast<size_t>(nextPow2(sizeof(FutureImplSmall<16, FNoRef, Result>)));
   using SmallT = FutureImplSmall<kImplSize, FNoRef, Result>;
 
   FutureImplBase<Result>* ret = new (allocSmallBuffer<kImplSize>()) SmallT(std::forward<F>(f));
@@ -403,7 +403,7 @@ createFutureImpl(F&& f, bool allowInline, std::atomic<ssize_t>* taskSetCounter) 
 
 template <typename Result, typename T>
 inline FutureImplBase<Result>* createValueFutureImplReady(T&& t) {
-  constexpr size_t kImplSize = nextPow2(sizeof(FutureImplSmall<16, void, Result>));
+  constexpr size_t kImplSize = static_cast<size_t>(nextPow2(sizeof(FutureImplSmall<16, void, Result>)));
   using SmallT = FutureImplSmall<kImplSize, void, Result>;
 
   FutureImplBase<Result>* ret = new (allocSmallBuffer<kImplSize>()) SmallT();
@@ -415,7 +415,7 @@ inline FutureImplBase<Result>* createValueFutureImplReady(T&& t) {
 
 template <typename X>
 inline FutureImplBase<X&>* createRefFutureImplReady(std::reference_wrapper<X> x) {
-  constexpr size_t kImplSize = nextPow2(sizeof(FutureImplSmall<16, void, X&>));
+  constexpr size_t kImplSize = static_cast<size_t>(nextPow2(sizeof(FutureImplSmall<16, void, X&>)));
   using SmallT = FutureImplSmall<kImplSize, void, X&>;
   FutureImplBase<X&>* ret = new (allocSmallBuffer<kImplSize>()) SmallT();
   ret->setAsResult(&x.get());
@@ -424,7 +424,7 @@ inline FutureImplBase<X&>* createRefFutureImplReady(std::reference_wrapper<X> x)
 }
 
 inline FutureImplBase<void>* createVoidFutureImplReady() {
-  constexpr size_t kImplSize = nextPow2(sizeof(FutureImplSmall<16, void, void>));
+  constexpr size_t kImplSize = static_cast<size_t>(nextPow2(sizeof(FutureImplSmall<16, void, void>)));
   using SmallT = FutureImplSmall<kImplSize, void, void>;
   FutureImplBase<void>* ret = new (allocSmallBuffer<kImplSize>()) SmallT();
   ret->setReady();

--- a/dispenso/detail/math.h
+++ b/dispenso/detail/math.h
@@ -49,9 +49,22 @@ constexpr inline uint32_t log2const(uint64_t v) {
 inline uint32_t log2(uint64_t v) {
   return static_cast<uint32_t>(63 - __builtin_clzll(v));
 }
+#elif defined(_WIN64)
+inline uint32_t log2(uint64_t v) {
+  unsigned long index;
+  _BitScanReverse64(&index, v);
+  return static_cast<uint32_t>(index);
+}
 #elif defined(_WIN32)
 inline uint32_t log2(uint64_t v) {
-  return static_cast<uint32_t>(63 - __lzcnt64(v));
+  unsigned long index;
+  uint32_t hi = static_cast<uint32_t>(v >> 32);
+  if (hi != 0) {
+    _BitScanReverse(&index, hi);
+    return static_cast<uint32_t>(index + 32);
+  }
+  _BitScanReverse(&index, static_cast<uint32_t>(v));
+  return static_cast<uint32_t>(index);
 }
 #else
 inline uint32_t log2(uint64_t v) {

--- a/dispenso/detail/once_callable_impl.h
+++ b/dispenso/detail/once_callable_impl.h
@@ -42,7 +42,7 @@ template <typename F>
 inline OnceCallable* createOnceCallable(F&& f) {
   using FNoRef = typename std::remove_reference<F>::type;
 
-  constexpr size_t kImplSize = nextPow2(sizeof(OnceCallableImpl<16, FNoRef>));
+  constexpr size_t kImplSize = static_cast<size_t>(nextPow2(sizeof(OnceCallableImpl<16, FNoRef>)));
 
   return new (allocSmallBuffer<kImplSize>())
       OnceCallableImpl<kImplSize, FNoRef>(std::forward<F>(f));

--- a/dispenso/for_each.h
+++ b/dispenso/for_each.h
@@ -22,6 +22,17 @@
 
 namespace dispenso {
 
+#if DISPENSO_HAS_CONCEPTS
+/**
+ * @concept ForEachFunc
+ * @brief A callable suitable for for_each operations.
+ *
+ * The callable must be invocable with a reference to the iterator's value type.
+ **/
+template <typename F, typename Iter>
+concept ForEachFunc = std::invocable<F, decltype(*std::declval<Iter>())>;
+#endif // DISPENSO_HAS_CONCEPTS
+
 /**
  * A set of options to control for_each
  **/
@@ -55,6 +66,7 @@ struct ForEachOptions {
  * @param options See ForEachOptions for details.
  **/
 template <typename TaskSetT, typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each_n(TaskSetT& tasks, Iter start, size_t n, F&& f, ForEachOptions options = {}) {
   // TODO(bbudge): With options.maxThreads, we might want to allow a small fanout factor in
   // recursive case?
@@ -144,6 +156,7 @@ void for_each_n(TaskSetT& tasks, Iter start, size_t n, F&& f, ForEachOptions opt
  * always wait, and therefore options.wait is ignored.
  **/
 template <typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each_n(Iter start, size_t n, F&& f, ForEachOptions options = {}) {
   TaskSet taskSet(globalThreadPool());
   options.wait = true;
@@ -162,6 +175,7 @@ void for_each_n(Iter start, size_t n, F&& f, ForEachOptions options = {}) {
  * @param options See ForEachOptions for details.
  **/
 template <typename TaskSetT, typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each(TaskSetT& tasks, Iter start, Iter end, F&& f, ForEachOptions options = {}) {
   for_each_n(tasks, start, std::distance(start, end), std::forward<F>(f), options);
 }
@@ -178,6 +192,7 @@ void for_each(TaskSetT& tasks, Iter start, Iter end, F&& f, ForEachOptions optio
  * always wait, and therefore options.wait is ignored.
  **/
 template <typename Iter, typename F>
+DISPENSO_REQUIRES(ForEachFunc<F, Iter>)
 void for_each(Iter start, Iter end, F&& f, ForEachOptions options = {}) {
   for_each_n(start, std::distance(start, end), std::forward<F>(f), options);
 }

--- a/dispenso/future.h
+++ b/dispenso/future.h
@@ -351,6 +351,7 @@ class Future<void> : detail::FutureBase<void> {
   Future(const Future& f) noexcept : Base(f) {}
   Future(const Base& f) noexcept : Base(f) {}
   template <typename F, typename Schedulable>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   Future(
       F&& f,
       Schedulable& schedulable,

--- a/dispenso/future.h
+++ b/dispenso/future.h
@@ -82,6 +82,7 @@ class Future : detail::FutureBase<Result> {
    * @param f The future to move from.
    **/
   Future(Future&& f) noexcept : Base(std::move(f)) {}
+  /** @copydoc Future(Future&&) */
   Future(Base&& f) noexcept : Base(std::move(f)) {}
 
   /**
@@ -91,6 +92,7 @@ class Future : detail::FutureBase<Result> {
    * the future's backing state.
    **/
   Future(const Future& f) noexcept : Base(f) {}
+  /** @copydoc Future(const Future&) */
   Future(const Base& f) noexcept : Base(f) {}
 
   /**
@@ -156,7 +158,7 @@ class Future : detail::FutureBase<Result> {
    * Is the Future ready?
    *
    * @return <code>true</code> if the value associated with this Future has already be computed, and
-   * <code>get</code> can return the value immediately.  Returns <false> if the functor is logically
+   * <code>get</code> can return the value immediately.  Returns <code>false</code> if the functor is logically
    * queued, or is in progress.
    **/
   bool is_ready() const {
@@ -222,7 +224,7 @@ class Future : detail::FutureBase<Result> {
   }
 
   /**
-   * Schedule a functor to be invoked upon reaching <code>is_ready<code> status, and return
+   * Schedule a functor to be invoked upon reaching <code>is_ready</code> status, and return
    * a future that will hold the result of the functor.
    *
    * @param f The functor to be executed whose result will be available in the returned
@@ -265,16 +267,25 @@ class Future : detail::FutureBase<Result> {
   friend class Future;
 };
 
+/**
+ * @copydoc Future
+ */
 template <typename Result>
 class Future<Result&> : detail::FutureBase<Result&> {
   using Base = detail::FutureBase<Result&>;
 
  public:
+  /** Default constructor. */
   Future() noexcept : Base() {}
+  /** Move constructor. */
   Future(Future&& f) noexcept : Base(std::move(f)) {}
+  /** @copydoc Future(Future&&) */
   Future(Base&& f) noexcept : Base(std::move(f)) {}
+  /** Copy constructor. */
   Future(const Future& f) noexcept : Base(f) {}
+  /** @copydoc Future(const Future&) */
   Future(const Base& f) noexcept : Base(f) {}
+  /** Construct with callable and schedulable. @see Future<Result>::Future(F&&, Schedulable&, std::launch, std::launch) */
   template <typename F, typename Schedulable>
   Future(
       F&& f,
@@ -340,16 +351,25 @@ class Future<Result&> : detail::FutureBase<Result&> {
   friend class Future;
 };
 
+/**
+ * @copydoc Future
+ */
 template <>
 class Future<void> : detail::FutureBase<void> {
   using Base = detail::FutureBase<void>;
 
  public:
+  /** Default constructor. */
   Future() noexcept : Base() {}
+  /** Move constructor. */
   Future(Future&& f) noexcept : Base(std::move(f)) {}
+  /** @copydoc Future(Future&&) */
   Future(Base&& f) noexcept : Base(std::move(f)) {}
+  /** Copy constructor. */
   Future(const Future& f) noexcept : Base(f) {}
+  /** @copydoc Future(const Future&) */
   Future(const Base& f) noexcept : Base(f) {}
+  /** Construct with callable and schedulable. @see Future<Result>::Future(F&&, Schedulable&, std::launch, std::launch) */
   template <typename F, typename Schedulable>
   DISPENSO_REQUIRES(OnceCallableFunc<F>)
   Future(
@@ -631,7 +651,7 @@ auto when_all(Futures&&... futures) -> Future<std::tuple<std::decay_t<Futures>..
  * Take a collection of futures, and return a future which will be ready when all input futures are
  * ready.
  *
- * @param tastSet A task set to register with such that after this call,
+ * @param taskSet A task set to register with such that after this call,
  * <code>taskSet::wait()</code> implies that the resultant future <code>is_ready()</code>
  * @param first An iterator to the start of the future collection.
  * @param last An iterator to the end of the future collection.
@@ -643,6 +663,7 @@ auto when_all(Futures&&... futures) -> Future<std::tuple<std::decay_t<Futures>..
 template <class InputIt>
 Future<std::vector<typename std::iterator_traits<InputIt>::value_type>>
 when_all(TaskSet& taskSet, InputIt first, InputIt last);
+/** @overload */
 template <class InputIt>
 Future<std::vector<typename std::iterator_traits<InputIt>::value_type>>
 when_all(ConcurrentTaskSet& taskSet, InputIt first, InputIt last);
@@ -651,7 +672,7 @@ when_all(ConcurrentTaskSet& taskSet, InputIt first, InputIt last);
  * Take a specific set of futures, and return a future which will be ready when all input futures
  *are ready.
  *
- * @param tastSet A task set to register with such that after this call,
+ * @param taskSet A task set to register with such that after this call,
  * <code>taskSet::wait()</code> implies that the resultant future <code>is_ready()</code>
  * @param futures A parameter pack of futures.
  *
@@ -663,6 +684,7 @@ template <class... Futures>
 auto when_all(TaskSet& taskSet, Futures&&... futures)
     -> Future<std::tuple<std::decay_t<Futures>...>>;
 
+/** @overload */
 template <class... Futures>
 auto when_all(ConcurrentTaskSet& taskSet, Futures&&... futures)
     -> Future<std::tuple<std::decay_t<Futures>...>>;

--- a/dispenso/graph.h
+++ b/dispenso/graph.h
@@ -493,7 +493,7 @@ class DISPENSO_DLL_ACCESS SubgraphT {
   using DeallocFunc = void (*)(NoLockPoolAllocator*);
   using PoolPtr = std::unique_ptr<NoLockPoolAllocator, DeallocFunc>;
 
-  static constexpr size_t kNodeSizeP2 = detail::nextPow2(sizeof(NodeType));
+  static constexpr size_t kNodeSizeP2 = static_cast<size_t>(detail::nextPow2(sizeof(NodeType)));
 
   explicit SubgraphT(GraphT<N>* graph) : graph_(graph), nodes_(), allocator_(getAllocator()) {}
 
@@ -672,7 +672,8 @@ class DISPENSO_DLL_ACCESS GraphT {
   }
 
  private:
-  static constexpr size_t kSubgraphSizeP2 = detail::nextPow2(sizeof(SubgraphType));
+  static constexpr size_t kSubgraphSizeP2 =
+      static_cast<size_t>(detail::nextPow2(sizeof(SubgraphType)));
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 #pragma warning(push)

--- a/dispenso/graph.h
+++ b/dispenso/graph.h
@@ -231,6 +231,7 @@ class Node {
   Node() = delete;
   Node(const Node&) = delete;
   Node& operator=(const Node&) = delete;
+  /** Move constructor. */
   Node(Node&& other) noexcept
       : numIncompletePredecessors_(other.numIncompletePredecessors_.load()),
         numPredecessors_(other.numPredecessors_),
@@ -324,6 +325,7 @@ class Node {
   }
 
  protected:
+  /** Construct a Node with a functor. @param f The functor to execute when the node runs. */
   template <class F, class X = std::enable_if_t<!std::is_base_of<Node, F>::value, void>>
   Node(F&& f) : numIncompletePredecessors_(0) {
     using FNoRef = typename std::remove_reference<F>::type;
@@ -368,6 +370,7 @@ class BiPropNode : public Node {
   BiPropNode() = delete;
   BiPropNode(const BiPropNode&) = delete;
   BiPropNode& operator=(const BiPropNode&) = delete;
+  /** Move constructor. */
   BiPropNode(BiPropNode&& other) noexcept
       : Node(std::move(other)), biPropSet_(std::move(other.biPropSet_)) {}
   /**
@@ -414,6 +417,11 @@ class BiPropNode : public Node {
 template <class N>
 class GraphT;
 
+/**
+ * A subgraph within a Graph, containing a collection of nodes that can be executed together.
+ *
+ * @tparam N The node type (Node or BiPropNode).
+ */
 template <class N>
 class DISPENSO_DLL_ACCESS SubgraphT {
  public:
@@ -421,6 +429,7 @@ class DISPENSO_DLL_ACCESS SubgraphT {
   SubgraphT() = delete;
   SubgraphT(const SubgraphT<N>&) = delete;
   SubgraphT<N>& operator=(const SubgraphT<N>&) = delete;
+  /** Move constructor. */
   SubgraphT(SubgraphT<N>&& other) noexcept
       : graph_(other.graph_),
         nodes_(std::move(other.nodes_)),
@@ -526,6 +535,15 @@ class DISPENSO_DLL_ACCESS SubgraphT {
   friend class GraphT;
 };
 
+/**
+ * A directed acyclic graph (DAG) for expressing task dependencies.
+ *
+ * GraphT manages a collection of subgraphs, each containing nodes that represent work to be done.
+ * Nodes can have dependencies on other nodes, and the graph executor ensures nodes run only after
+ * their dependencies complete.
+ *
+ * @tparam N The node type (Node or BiPropNode).
+ */
 template <class N>
 class DISPENSO_DLL_ACCESS GraphT {
  public:
@@ -688,9 +706,13 @@ class DISPENSO_DLL_ACCESS GraphT {
   friend class SubgraphT;
 };
 
+/** A DAG for task scheduling with simple dependency tracking. */
 using Graph = GraphT<Node>;
+/** A DAG for task scheduling with bidirectional dependency propagation. */
 using BiPropGraph = GraphT<BiPropNode>;
 
+/** A subgraph within a Graph. */
 using Subgraph = SubgraphT<Node>;
+/** A subgraph within a BiPropGraph. */
 using BiPropSubgraph = SubgraphT<BiPropNode>;
 } // namespace dispenso

--- a/dispenso/graph.h
+++ b/dispenso/graph.h
@@ -20,9 +20,11 @@
 #include <type_traits>
 #include <vector>
 
+#include <dispenso/once_function.h>
 #include <dispenso/platform.h>
 #include <dispenso/pool_allocator.h>
 #include <dispenso/small_buffer_allocator.h>
+
 /*
 Terminology
 --------------------------------------------------------------------------------
@@ -431,6 +433,7 @@ class DISPENSO_DLL_ACCESS SubgraphT {
    * @return reference to the created node.
    **/
   template <class T>
+  DISPENSO_REQUIRES(OnceCallableFunc<T>)
   N& addNode(T&& f) {
     nodes_.push_back(new (allocator_->alloc()) NodeType(std::forward<T>(f)));
     return *nodes_.back();
@@ -551,6 +554,7 @@ class DISPENSO_DLL_ACCESS GraphT {
    * @param f A functor with signature void().
    **/
   template <class T>
+  DISPENSO_REQUIRES(OnceCallableFunc<T>)
   N& addNode(T&& f) {
     return subgraphs_[0].addNode(std::forward<T>(f));
   }

--- a/dispenso/once_function.h
+++ b/dispenso/once_function.h
@@ -75,6 +75,7 @@ class OnceFunction {
 
   OnceFunction(const OnceFunction& other) = delete;
 
+  /** Move constructor. */
   OnceFunction(OnceFunction&& other) : onceCallable_(other.onceCallable_) {
 #if defined DISPENSO_DEBUG
     other.onceCallable_ = nullptr;

--- a/dispenso/once_function.h
+++ b/dispenso/once_function.h
@@ -17,8 +17,23 @@
 #include <utility>
 
 #include <dispenso/detail/once_callable_impl.h>
+#include <dispenso/platform.h>
 
 namespace dispenso {
+
+#if DISPENSO_HAS_CONCEPTS
+/**
+ * @concept OnceCallableFunc
+ * @brief A callable suitable for wrapping in OnceFunction or scheduling as a task.
+ *
+ * The callable must be invocable with no arguments. The return value (if any) is discarded.
+ * This is the fundamental requirement for functors passed to OnceFunction,
+ * ThreadPool::schedule, TaskSet::schedule, and similar scheduling interfaces.
+ **/
+template <typename F>
+concept OnceCallableFunc = std::invocable<F>;
+#endif // DISPENSO_HAS_CONCEPTS
+
 namespace detail {
 template <typename Result>
 class FutureBase;
@@ -55,6 +70,7 @@ class OnceFunction {
    * overhead for double type erasure.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   OnceFunction(F&& f) : onceCallable_(detail::createOnceCallable(std::forward<F>(f))) {}
 
   OnceFunction(const OnceFunction& other) = delete;

--- a/dispenso/parallel_for.h
+++ b/dispenso/parallel_for.h
@@ -23,6 +23,44 @@
 
 namespace dispenso {
 
+#if DISPENSO_HAS_CONCEPTS
+/**
+ * @concept ParallelForRangeFunc
+ * @brief A callable suitable for chunked parallel_for with (begin, end) signature.
+ *
+ * The callable must be invocable with two integer arguments representing the chunk range.
+ **/
+template <typename F, typename IntegerT>
+concept ParallelForRangeFunc = std::invocable<F, IntegerT, IntegerT>;
+
+/**
+ * @concept ParallelForIndexFunc
+ * @brief A callable suitable for element-wise parallel_for with single index signature.
+ *
+ * The callable must be invocable with a single integer argument representing the element index.
+ **/
+template <typename F, typename IntegerT>
+concept ParallelForIndexFunc = std::invocable<F, IntegerT>;
+
+/**
+ * @concept ParallelForStateRangeFunc
+ * @brief A callable suitable for stateful chunked parallel_for.
+ *
+ * The callable must be invocable with (State&, begin, end) arguments.
+ **/
+template <typename F, typename StateRef, typename IntegerT>
+concept ParallelForStateRangeFunc = std::invocable<F, StateRef, IntegerT, IntegerT>;
+
+/**
+ * @concept ParallelForStateIndexFunc
+ * @brief A callable suitable for stateful element-wise parallel_for.
+ *
+ * The callable must be invocable with (State&, index) arguments.
+ **/
+template <typename F, typename StateRef, typename IntegerT>
+concept ParallelForStateIndexFunc = std::invocable<F, StateRef, IntegerT>;
+#endif // DISPENSO_HAS_CONCEPTS
+
 /**
  * Chunking strategy.  Typically if the cost of each loop iteration is roughly constant, kStatic
  * load balancing is preferred.  Additionally, when making a non-waiting parallel_for call in
@@ -513,6 +551,7 @@ void parallel_for(
  * @param options See ParForOptions for details.
  **/
 template <typename TaskSetT, typename IntegerT, typename F>
+DISPENSO_REQUIRES(ParallelForRangeFunc<F, IntegerT>)
 void parallel_for(
     TaskSetT& taskSet,
     const ChunkedRange<IntegerT>& range,
@@ -538,6 +577,7 @@ void parallel_for(
  *to true.
  **/
 template <typename IntegerT, typename F>
+DISPENSO_REQUIRES(ParallelForRangeFunc<F, IntegerT>)
 void parallel_for(const ChunkedRange<IntegerT>& range, F&& f, ParForOptions options = {}) {
   TaskSet taskSet(globalThreadPool());
   options.wait = true;

--- a/dispenso/parallel_for.h
+++ b/dispenso/parallel_for.h
@@ -651,6 +651,16 @@ void parallel_for(
       options);
 }
 
+/**
+ * Execute loop over the range in parallel using the provided task set.
+ *
+ * @param taskSet The task set to use for scheduling parallel work.
+ * @param start The start of the loop extents.
+ * @param end The end of the loop extents.
+ * @param f The functor to execute in parallel.  Must have a signature like
+ * <code>void(size_t begin, size_t end)</code>.
+ * @param options See ParForOptions for details.
+ **/
 template <
     typename TaskSetT,
     typename IntegerA,
@@ -744,6 +754,18 @@ void parallel_for(
       options);
 }
 
+/**
+ * Execute loop over the range in parallel using the provided task set, with per-thread state.
+ *
+ * @param taskSet The task set to use for scheduling parallel work.
+ * @param states A container of per-thread state objects.
+ * @param defaultState A functor to generate default state for new threads.
+ * @param start The start of the loop extents.
+ * @param end The end of the loop extents.
+ * @param f The functor to execute in parallel.  Must have a signature like
+ * <code>void(State& state, size_t begin, size_t end)</code>.
+ * @param options See ParForOptions for details.
+ **/
 template <
     typename TaskSetT,
     typename IntegerA,

--- a/dispenso/platform.h
+++ b/dispenso/platform.h
@@ -26,6 +26,34 @@ namespace dispenso {
 #define DISPENSO_MINOR_VERSION 4
 #define DISPENSO_PATCH_VERSION 1
 
+// C++20 concepts support detection
+#if __cplusplus >= 202002L && defined(__cpp_concepts) && __cpp_concepts >= 201907L
+#define DISPENSO_HAS_CONCEPTS 1
+#include <concepts>
+#else
+#define DISPENSO_HAS_CONCEPTS 0
+#endif
+
+/**
+ * @def DISPENSO_REQUIRES
+ * @brief Macro for conditionally applying C++20 concept constraints.
+ *
+ * On C++20 with concepts support, this expands to a requires clause.
+ * On C++14/17, this expands to nothing, maintaining backward compatibility.
+ *
+ * Example usage:
+ * @code
+ * template <typename F>
+ * DISPENSO_REQUIRES(std::invocable<F>)
+ * void schedule(F&& f);
+ * @endcode
+ **/
+#if DISPENSO_HAS_CONCEPTS
+#define DISPENSO_REQUIRES(...) requires(__VA_ARGS__)
+#else
+#define DISPENSO_REQUIRES(...)
+#endif
+
 #if defined(DISPENSO_SHARED_LIB)
 #if defined _WIN32
 

--- a/dispenso/platform.h
+++ b/dispenso/platform.h
@@ -137,10 +137,18 @@ constexpr size_t kCacheLineSize = 64;
 #endif
 // clang-format on
 
+/**
+ * A wrapper that aligns the contained value to cache line boundaries.
+ *
+ * Useful for avoiding false sharing in concurrent data structures.
+ *
+ * @tparam T The type to wrap with cache line alignment.
+ */
 template <typename T>
 class CacheAligned {
  public:
   CacheAligned() = default;
+  /** Construct from a value. @param t The value to wrap. */
   CacheAligned(T t) : t_(t) {}
   operator T&() {
     return t_;

--- a/dispenso/pool_allocator.h
+++ b/dispenso/pool_allocator.h
@@ -92,7 +92,9 @@ class PoolAllocatorT {
   std::vector<char*> chunks_;
 };
 
+/** Thread-safe pool allocator with internal locking. */
 using PoolAllocator = PoolAllocatorT<true>;
+/** Pool allocator without locking, for single-threaded use or external synchronization. */
 using NoLockPoolAllocator = PoolAllocatorT<false>;
 
 } // namespace dispenso

--- a/dispenso/resource_pool.h
+++ b/dispenso/resource_pool.h
@@ -30,6 +30,7 @@ class ResourcePool;
 template <typename T>
 class Resource {
  public:
+  /** Move constructor. */
   Resource(Resource&& other) : resource_(other.resource_), pool_(other.pool_) {
     other.resource_ = nullptr;
   }

--- a/dispenso/schedulable.h
+++ b/dispenso/schedulable.h
@@ -35,6 +35,7 @@ class ImmediateInvoker {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f) const {
     f();
   }
@@ -45,6 +46,7 @@ class ImmediateInvoker {
    *
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag) const {
     f();
   }
@@ -67,6 +69,7 @@ class NewThreadInvoker {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f) const {
     schedule(std::forward<F>(f), ForceQueuingTag());
   }
@@ -78,6 +81,7 @@ class NewThreadInvoker {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag) const {
     std::thread thread([f = std::move(f)]() { f(); });
     thread.detach();

--- a/dispenso/task_set.h
+++ b/dispenso/task_set.h
@@ -72,6 +72,7 @@ class TaskSet : public TaskSetBase {
    * in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f) {
     if (DISPENSO_EXPECT(canceled(), false)) {
       return;
@@ -95,6 +96,7 @@ class TaskSet : public TaskSetBase {
    * from the set is rethrown in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag fq) {
     pool_.schedule(token_, packageTask(std::forward<F>(f)), fq);
   }
@@ -211,6 +213,7 @@ class ConcurrentTaskSet : public TaskSetBase {
    * in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, bool skipRecheck = false) {
     if (outstandingTaskCount_.load(std::memory_order_relaxed) > taskSetLoadFactor_ &&
         DISPENSO_EXPECT(!canceled(), true)) {
@@ -234,6 +237,7 @@ class ConcurrentTaskSet : public TaskSetBase {
    * from the set is rethrown in <code>wait</code>.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag fq) {
     pool_.schedule(packageTask(std::forward<F>(f)), fq);
   }

--- a/dispenso/task_set.h
+++ b/dispenso/task_set.h
@@ -40,7 +40,8 @@ class TaskSet : public TaskSetBase {
   /**
    * Construct a TaskSet with the given backing pool.
    *
-   * @param pool The backing pool for this TaskSet
+   * @param p The backing pool for this TaskSet
+   * @param registerForParentCancel Whether to register for parent cancellation cascade.
    * @param stealingLoadMultiplier An over-load factor.  If this factor of load is reached by the
    * underlying pool, scheduled tasks may run immediately in the calling thread.
    **/
@@ -51,7 +52,9 @@ class TaskSet : public TaskSetBase {
       : TaskSetBase(p, registerForParentCancel, stealingLoadMultiplier),
         token_(makeToken(p.work_)) {}
 
+  /** Construct a TaskSet with default options. @param p The backing pool. */
   TaskSet(ThreadPool& p) : TaskSet(p, ParentCascadeCancel::kOff, kDefaultStealingMultiplier) {}
+  /** Construct a TaskSet with custom load multiplier. @param p The backing pool. @param stealingLoadMultiplier The over-load factor. */
   TaskSet(ThreadPool& p, ssize_t stealingLoadMultiplier)
       : TaskSet(p, ParentCascadeCancel::kOff, stealingLoadMultiplier) {}
 
@@ -90,6 +93,7 @@ class TaskSet : public TaskSetBase {
    * @param f A functor matching signature <code>void()</code>.  Best performance will come from
    * passing lambdas, other concrete functors, or <code>OnceFunction</code>, but
    * <code>std::function</code> or similarly type-erased objects will also work.
+   * @param fq Tag to force queuing instead of potential inline execution.
    *
    * @note If <code>f</code> can throw exceptions, then exceptions will be caught on the running
    * thread and best-effort propagated to the <code>ConcurrentTaskSet</code>, where the first one
@@ -179,6 +183,7 @@ class ConcurrentTaskSet : public TaskSetBase {
    * Construct a ConcurrentTaskSet with the given backing pool.
    *
    * @param pool The backing pool for this ConcurrentTaskSet
+   * @param registerForParentCancel Whether to register for parent cancellation cascade.
    * @param stealingLoadMultiplier An over-load factor.  If this factor of load is reached by the
    * underlying pool, scheduled tasks may run immediately in the calling thread.
    **/
@@ -188,8 +193,10 @@ class ConcurrentTaskSet : public TaskSetBase {
       ssize_t stealingLoadMultiplier = kDefaultStealingMultiplier)
       : TaskSetBase(pool, registerForParentCancel, stealingLoadMultiplier) {}
 
+  /** Construct a ConcurrentTaskSet with default options. @param p The backing pool. */
   ConcurrentTaskSet(ThreadPool& p)
       : ConcurrentTaskSet(p, ParentCascadeCancel::kOff, kDefaultStealingMultiplier) {}
+  /** Construct a ConcurrentTaskSet with custom load multiplier. @param p The backing pool. @param stealingLoadMultiplier The over-load factor. */
   ConcurrentTaskSet(ThreadPool& p, ssize_t stealingLoadMultiplier)
       : ConcurrentTaskSet(p, ParentCascadeCancel::kOff, stealingLoadMultiplier) {}
 
@@ -231,6 +238,7 @@ class ConcurrentTaskSet : public TaskSetBase {
    * @param f A functor matching signature <code>void()</code>.  Best performance will come from
    * passing lambdas, other concrete functors, or <code>OnceFunction</code>, but
    * <code>std::function</code> or similarly type-erased objects will also work.
+   * @param fq Tag to force queuing instead of potential inline execution.
    *
    * @note If <code>f</code> can throw exceptions, then exceptions will be caught on the running
    * thread and best-effort propagated to the <code>ConcurrentTaskSet</code>, where the first one

--- a/dispenso/thread_pool.h
+++ b/dispenso/thread_pool.h
@@ -141,6 +141,7 @@ class alignas(kCacheLineSize) ThreadPool {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f);
 
   /**
@@ -152,6 +153,7 @@ class alignas(kCacheLineSize) ThreadPool {
    * std::function or similarly type-erased objects will also work.
    **/
   template <typename F>
+  DISPENSO_REQUIRES(OnceCallableFunc<F>)
   void schedule(F&& f, ForceQueuingTag);
 
   /**
@@ -270,6 +272,7 @@ DISPENSO_DLL_ACCESS void resizeGlobalThreadPool(size_t numThreads);
 // ----------------------------- Implementation details -------------------------------------
 
 template <typename F>
+DISPENSO_REQUIRES(OnceCallableFunc<F>)
 inline void ThreadPool::schedule(F&& f) {
   ssize_t curWork = workRemaining_.load(std::memory_order_relaxed);
   ssize_t quickLoadFactor = numThreads_.load(std::memory_order_relaxed);
@@ -283,6 +286,7 @@ inline void ThreadPool::schedule(F&& f) {
 }
 
 template <typename F>
+DISPENSO_REQUIRES(OnceCallableFunc<F>)
 inline void ThreadPool::schedule(F&& f, ForceQueuingTag) {
   if (auto* token =
           static_cast<moodycamel::ProducerToken*>(detail::PerPoolPerThreadInfo::producer(this))) {

--- a/dispenso/timed_task.h
+++ b/dispenso/timed_task.h
@@ -42,6 +42,7 @@ enum class TimedTaskType {
 class TimedTask {
  public:
   TimedTask(const TimedTask&) = delete;
+  /** Move constructor. */
   TimedTask(TimedTask&& other) : impl_(std::move(other.impl_)) {}
 
   TimedTask& operator=(const TimedTask&) = delete;

--- a/dispenso/timing.h
+++ b/dispenso/timing.h
@@ -17,6 +17,13 @@
 
 namespace dispenso {
 
+/**
+ * Get elapsed time in seconds since program start.
+ *
+ * Uses high-resolution timing when available (e.g., RDTSC on x86).
+ *
+ * @return Elapsed time in seconds as a double.
+ */
 DISPENSO_DLL_ACCESS double getTime();
 
 } // namespace dispenso

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -816,50 +816,15 @@ INPUT_ENCODING         = UTF-8
 # *.m, *.markdown, *.md, *.mm, *.dox, *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f, *.for, *.tcl, *.vhd, *.vhdl, *.ucf and *.qsf.
 
-FILE_PATTERNS          = *.c \
-                         *.cc \
-                         *.cxx \
-                         *.cpp \
-                         *.c++ \
-                         *.java \
-                         *.ii \
-                         *.ixx \
-                         *.ipp \
-                         *.i++ \
-                         *.inl \
-                         *.idl \
-                         *.ddl \
-                         *.odl \
-                         *.h \
+FILE_PATTERNS          = *.h \
                          *.hh \
                          *.hxx \
                          *.hpp \
                          *.h++ \
-                         *.cs \
-                         *.d \
-                         *.php \
-                         *.php4 \
-                         *.php5 \
-                         *.phtml \
-                         *.inc \
-                         *.m \
+                         *.inl \
                          *.markdown \
                          *.md \
-                         *.mm \
-                         *.dox \
-                         *.py \
-                         *.pyw \
-                         *.f90 \
-                         *.f95 \
-                         *.f03 \
-                         *.f08 \
-                         *.f \
-                         *.for \
-                         *.tcl \
-                         *.vhd \
-                         *.vhdl \
-                         *.ucf \
-                         *.qsf
+                         *.dox
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -902,7 +867,50 @@ EXCLUDE_PATTERNS       = dispenso::detail::*
 # exclude all test directories use the pattern */test/*
 
 EXCLUDE_SYMBOLS        = dispenso::detail::* \
-                         *detail*
+                         *detail* \
+                         DISPENSO_* \
+                         TaskSetBase \
+                         ChunkedRange \
+                         ForceQueuingTag \
+                         value_type \
+                         reference \
+                         const_reference \
+                         size_type \
+                         difference_type \
+                         reference_type \
+                         const_reference_type \
+                         pointer \
+                         const_pointer \
+                         iterator \
+                         const_iterator \
+                         reverse_iterator \
+                         const_reverse_iterator \
+                         NodeType \
+                         SubgraphType \
+                         OpResult \
+                         ssize_t \
+                         kDefault* \
+                         kImmediate* \
+                         kNewThread* \
+                         kCompleted \
+                         kStatic \
+                         ParentCascadeCancel \
+                         operator== \
+                         operator!= \
+                         operator< \
+                         operator> \
+                         operator<= \
+                         operator>= \
+                         operator* \
+                         "operator new" \
+                         "operator delete" \
+                         swap \
+                         share \
+                         then \
+                         numIncompletePredecessors_ \
+                         numPredecessors_ \
+                         dependsOnOneNode \
+                         DO_PRAGMA
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include
@@ -2072,7 +2080,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = 
+INCLUDE_PATH           = ../dispenso/detail
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the
@@ -2090,7 +2098,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = 
+PREDEFINED             = __GNUC__
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -183,7 +183,7 @@ Key points:
 
 ## Next Steps
 
-- Browse the @ref modules "API Reference" for complete documentation
+- Browse the [API Reference](modules.html) for complete documentation
 - Check out the [tests](https://github.com/facebookincubator/dispenso/tree/main/tests)
   for more usage examples
 - See the [benchmarks](https://github.com/facebookincubator/dispenso/tree/main/benchmarks)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,12 +43,11 @@ file(GLOB TEST_FILES CONFIGURE_DEPENDS "*test.cpp")
 LIST(REMOVE_ITEM TEST_FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/shared_pool_test.cpp)
 
-# Filter out these tests specifically because they are inherently flaky because they rely on OS behaviors that are not
-# guaranteed, and only really useful for manual runs when making changes to the related functionality.  Note that
-# possibly an even better test for both priority and timed_task behavior is to use the timed_task_benchmark.
+# Filter out priority_test specifically because it is inherently flaky - it relies on OS scheduling
+# behaviors that are not guaranteed, and is only really useful for manual runs when making changes
+# to the related functionality.
 LIST(REMOVE_ITEM TEST_FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/priority_test.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/timed_task_test.cpp)
+  ${CMAKE_CURRENT_SOURCE_DIR}/priority_test.cpp)
 
 foreach(TEST_FILE ${TEST_FILES})
   set(TEST_NAME)
@@ -56,7 +55,7 @@ foreach(TEST_FILE ${TEST_FILES})
   package_add_test(${TEST_NAME} unittest ${TEST_FILE})
 endforeach()
 
-SET(FLAKY_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/priority_test.cpp ${CMAKE_CURRENT_SOURCE_DIR}/timed_task_test.cpp)
+SET(FLAKY_TEST_FILES ${CMAKE_CURRENT_SOURCE_DIR}/priority_test.cpp)
 
 foreach(TEST_FILE ${FLAKY_TEST_FILES})
   set(TEST_NAME)

--- a/tests/pool_allocator_test.cpp
+++ b/tests/pool_allocator_test.cpp
@@ -151,3 +151,176 @@ TEST(PoolAllocator, Arena) {
     EXPECT_TRUE(std::all_of(c, c + 64, [](char v) { return v == 0x11; }));
   }
 }
+
+TEST(NoLockPoolAllocator, SimpleMallocFree) {
+  // Test the non-thread-safe version
+  dispenso::NoLockPoolAllocator allocator(64, 256, ::malloc, ::free);
+
+  char* buf = allocator.alloc();
+  *buf = 'a';
+  allocator.dealloc(buf);
+}
+
+TEST(NoLockPoolAllocator, MultipleAllocDealloc) {
+  dispenso::NoLockPoolAllocator allocator(32, 128, ::malloc, ::free);
+
+  // Allocate several chunks
+  std::vector<char*> bufs;
+  for (int i = 0; i < 10; ++i) {
+    char* buf = allocator.alloc();
+    std::fill_n(buf, 32, static_cast<char>(i));
+    bufs.push_back(buf);
+  }
+
+  // Verify contents
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_TRUE(std::all_of(bufs[static_cast<size_t>(i)], bufs[static_cast<size_t>(i)] + 32,
+                            [i](char v) { return v == static_cast<char>(i); }));
+  }
+
+  // Dealloc all
+  for (char* buf : bufs) {
+    allocator.dealloc(buf);
+  }
+}
+
+TEST(PoolAllocator, TotalChunkCapacity) {
+  size_t allocCount = 0;
+  auto allocFunc = [&allocCount](size_t len) -> void* {
+    ++allocCount;
+    return ::malloc(len);
+  };
+
+  dispenso::PoolAllocator allocator(64, 256, allocFunc, ::free);
+
+  // Initially no backing allocations
+  EXPECT_EQ(allocator.totalChunkCapacity(), 0u);
+
+  // First alloc triggers a backing allocation
+  char* buf1 = allocator.alloc();
+  EXPECT_EQ(allocCount, 1u);
+  EXPECT_EQ(allocator.totalChunkCapacity(), 4u); // 256 / 64 = 4 chunks
+
+  // Allocate remaining chunks in first slab
+  char* buf2 = allocator.alloc();
+  char* buf3 = allocator.alloc();
+  char* buf4 = allocator.alloc();
+  EXPECT_EQ(allocCount, 1u); // Still just 1 backing allocation
+  EXPECT_EQ(allocator.totalChunkCapacity(), 4u);
+
+  // Next alloc triggers another backing allocation
+  char* buf5 = allocator.alloc();
+  EXPECT_EQ(allocCount, 2u);
+  EXPECT_EQ(allocator.totalChunkCapacity(), 8u); // 2 slabs * 4 chunks
+
+  allocator.dealloc(buf1);
+  allocator.dealloc(buf2);
+  allocator.dealloc(buf3);
+  allocator.dealloc(buf4);
+  allocator.dealloc(buf5);
+}
+
+TEST(PoolAllocator, SingleChunkPerSlab) {
+  // Edge case: chunkSize equals allocSize, so only 1 chunk per slab
+  size_t allocCount = 0;
+  auto allocFunc = [&allocCount](size_t len) -> void* {
+    ++allocCount;
+    return ::malloc(len);
+  };
+
+  dispenso::PoolAllocator allocator(128, 128, allocFunc, ::free);
+
+  EXPECT_EQ(allocator.totalChunkCapacity(), 0u);
+
+  char* buf1 = allocator.alloc();
+  EXPECT_EQ(allocCount, 1u);
+  EXPECT_EQ(allocator.totalChunkCapacity(), 1u);
+
+  char* buf2 = allocator.alloc();
+  EXPECT_EQ(allocCount, 2u);
+  EXPECT_EQ(allocator.totalChunkCapacity(), 2u);
+
+  allocator.dealloc(buf1);
+  allocator.dealloc(buf2);
+}
+
+TEST(PoolAllocator, ClearEmptyAllocator) {
+  // Edge case: calling clear() when nothing has been allocated
+  dispenso::PoolAllocator allocator(64, 256, ::malloc, ::free);
+
+  // Should not crash
+  allocator.clear();
+  allocator.clear();
+
+  // Can still allocate after clear
+  char* buf = allocator.alloc();
+  *buf = 'x';
+  EXPECT_EQ(*buf, 'x');
+  allocator.dealloc(buf);
+}
+
+TEST(PoolAllocator, MultipleClearCycles) {
+  size_t allocCount = 0;
+  size_t deallocCount = 0;
+
+  auto allocFunc = [&allocCount](size_t len) -> void* {
+    ++allocCount;
+    return ::malloc(len);
+  };
+
+  auto deallocFunc = [&deallocCount](void* ptr) {
+    ++deallocCount;
+    ::free(ptr);
+  };
+
+  {
+    dispenso::PoolAllocator allocator(64, 256, allocFunc, deallocFunc);
+
+    // First cycle
+    std::vector<char*> bufs;
+    for (int i = 0; i < 20; ++i) {
+      bufs.push_back(allocator.alloc());
+    }
+    size_t firstCycleAllocs = allocCount;
+    EXPECT_GT(firstCycleAllocs, 0u);
+
+    allocator.clear();
+    EXPECT_EQ(deallocCount, 0u); // clear() doesn't deallocate
+
+    // Second cycle - should reuse backing allocations
+    bufs.clear();
+    for (int i = 0; i < 10; ++i) {
+      bufs.push_back(allocator.alloc());
+    }
+    EXPECT_EQ(allocCount, firstCycleAllocs); // No new backing allocations
+
+    allocator.clear();
+
+    // Third cycle
+    bufs.clear();
+    for (int i = 0; i < 5; ++i) {
+      bufs.push_back(allocator.alloc());
+    }
+    EXPECT_EQ(allocCount, firstCycleAllocs); // Still no new backing allocations
+  }
+
+  // Destructor deallocates all backing allocations
+  EXPECT_EQ(deallocCount, allocCount);
+}
+
+TEST(PoolAllocator, ReuseAfterDealloc) {
+  // Verify that deallocated chunks are reused
+  dispenso::PoolAllocator allocator(64, 256, ::malloc, ::free);
+
+  char* buf1 = allocator.alloc();
+  std::fill_n(buf1, 64, 'A');
+
+  allocator.dealloc(buf1);
+
+  // Next alloc should return the same chunk (LIFO behavior)
+  char* buf2 = allocator.alloc();
+  EXPECT_EQ(buf1, buf2);
+
+  // Contents may have been overwritten, but that's expected
+  allocator.dealloc(buf2);
+}

--- a/tests/timing_test.cpp
+++ b/tests/timing_test.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <dispenso/timing.h>
+
+#include <chrono>
+#include <cmath>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// These tests are disabled under TSAN because timing-based tests are inherently
+// sensitive to instrumentation overhead and thread scheduling, making them flaky
+// in sanitizer builds.
+
+#if !DISPENSO_HAS_TSAN
+
+TEST(Timing, GetTimeReturnsNonNegative) {
+  double t = dispenso::getTime();
+  EXPECT_GE(t, 0.0);
+}
+
+TEST(Timing, GetTimeIsMonotonic) {
+  double prev = dispenso::getTime();
+  for (int i = 0; i < 100; ++i) {
+    double cur = dispenso::getTime();
+    EXPECT_GE(cur, prev);
+    prev = cur;
+  }
+}
+
+TEST(Timing, GetTimeProgresses) {
+  double start = dispenso::getTime();
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  double end = dispenso::getTime();
+
+  // After sleeping 10ms, time should have advanced by at least 5ms
+  // (allowing for timing imprecision)
+  EXPECT_GT(end - start, 0.005);
+}
+
+TEST(Timing, StatisticalAccuracy) {
+  // Run many iterations and verify that most measurements are within tolerance
+  // of std::chrono. This is a statistical test that allows for some outliers
+  // due to OS scheduling, context switches, etc.
+
+  constexpr int kIterations = 1000;
+  constexpr int kMinSuccesses = 900; // 90% must pass
+  constexpr double kToleranceSeconds = 2e-6; // 2 microseconds tolerance
+
+  int successes = 0;
+
+  for (int i = 0; i < kIterations; ++i) {
+    auto chronoStart = std::chrono::high_resolution_clock::now();
+    double dispensoStart = dispenso::getTime();
+
+    // Small busy-wait to accumulate some time
+    volatile int dummy = 0;
+    for (int j = 0; j < 1000; ++j) {
+      dummy += j;
+    }
+    (void)dummy;
+
+    auto chronoEnd = std::chrono::high_resolution_clock::now();
+    double dispensoEnd = dispenso::getTime();
+
+    double chronoElapsed =
+        std::chrono::duration<double>(chronoEnd - chronoStart).count();
+    double dispensoElapsed = dispensoEnd - dispensoStart;
+
+    // Check if the measurements are within tolerance
+    double diff = std::abs(chronoElapsed - dispensoElapsed);
+    if (diff < kToleranceSeconds) {
+      ++successes;
+    }
+  }
+
+  EXPECT_GE(successes, kMinSuccesses)
+      << "Expected at least " << kMinSuccesses << " out of " << kIterations
+      << " timing measurements to be within " << (kToleranceSeconds * 1e6)
+      << "us tolerance, but only " << successes << " were.";
+}
+
+TEST(Timing, LongerDurationAccuracy) {
+  // Test accuracy over a longer duration (more reliable)
+  constexpr int kIterations = 10;
+  constexpr double kSleepSeconds = 0.02; // 20ms
+  constexpr double kToleranceRatio = 0.25; // 25% tolerance
+
+  for (int i = 0; i < kIterations; ++i) {
+    double start = dispenso::getTime();
+    std::this_thread::sleep_for(
+        std::chrono::microseconds(static_cast<int64_t>(kSleepSeconds * 1e6)));
+    double end = dispenso::getTime();
+
+    double elapsed = end - start;
+
+    // Elapsed should be close to sleep duration
+    // Allow for OS scheduling variance
+    EXPECT_GE(elapsed, kSleepSeconds * (1.0 - kToleranceRatio))
+        << "Iteration " << i << ": elapsed time " << elapsed
+        << " is too short compared to sleep duration " << kSleepSeconds;
+
+    // Upper bound is more lenient since OS can delay wakeup
+    EXPECT_LE(elapsed, kSleepSeconds * 3.0)
+        << "Iteration " << i << ": elapsed time " << elapsed
+        << " is way too long compared to sleep duration " << kSleepSeconds;
+  }
+}
+
+TEST(Timing, RapidCalls) {
+  // Verify that rapid successive calls don't produce anomalies
+  constexpr int kIterations = 10000;
+  double times[kIterations];
+
+  for (int i = 0; i < kIterations; ++i) {
+    times[i] = dispenso::getTime();
+  }
+
+  // All times should be monotonically non-decreasing
+  for (int i = 1; i < kIterations; ++i) {
+    EXPECT_GE(times[i], times[i - 1]) << "Time went backwards at index " << i;
+  }
+
+  // Total elapsed time should be small (< 1 second for 10k calls)
+  double totalElapsed = times[kIterations - 1] - times[0];
+  EXPECT_LT(totalElapsed, 1.0)
+      << "10000 getTime() calls took " << totalElapsed << " seconds";
+}
+
+#endif // !DISPENSO_HAS_TSAN


### PR DESCRIPTION
Summary:
Add statistical success criteria and relaxed tolerances to timing-sensitive
tests to make them reliable for CI environments.

Changes:
- Add CI tolerance multiplier (DISPENSO_CI_TIMING_TOLERANCE, default 2.0x)
  that relaxes timing constraints in CI where timing is less predictable
- Add runWithStatisticalSuccess() helper that runs timing tests multiple
  times and requires 8/10 passes (80% success rate)
- Wrap flaky periodic timing tests (RunPeriodic, RunPeriodicSteady,
  RunPeriodicDontWait, RunPeriodicSteadyUnderLoad, RunDetach) with the
  statistical success helper
- Use return values instead of exceptions for cleaner failure handling
- Remove timed_task_test from FLAKY_TEST_FILES in CMakeLists.txt so it
  runs in CI (can be reintroduced if we see failures)

The combination of 2x tolerance and 8/10 statistical threshold should make
these tests >99.99% reliable while still catching real timing regressions.

Code Coverage:
The dispenso library now has 94.6% line coverage (3892/4114 lines) as
measured by lcov/gcov. The remaining uncovered code consists primarily of:
- Debug assertions and error paths (abort on invalid state)
- Platform-specific privilege elevation code (setrlimit/nice)
- Edge cases in third-party moodycamel queue

Differential Revision: D91946190
