### PR TITLE
Fix remaining CI build failures across platforms (#63)

### DIFF
--- a/dispenso/CMakeLists.txt
+++ b/dispenso/CMakeLists.txt
@@ -28,7 +28,9 @@ endif()
 
 target_compile_options(dispenso PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W3 /WX>
-  $<$<CXX_COMPILER_ID:GNU>: -Wno-stringop-overflow>
+  # GCC 13 false positive: stringop-overflow through deeply inlined atomics.
+  # GCC 14+ does not trigger this.  Revisit when CI moves off GCC 13.
+  $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,14>>:-Wno-stringop-overflow>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic -Wconversion -Wno-sign-conversion -Werror>
 )
 

--- a/dispenso/parallel_for.h
+++ b/dispenso/parallel_for.h
@@ -383,17 +383,18 @@ void parallel_for_staticImpl(
           IntegerT thisChunkSize;
           if (static_cast<size_type>(idx) < transitionIdx) {
             IntegerT i = static_cast<IntegerT>(idx);
-            start = range.start + static_cast<IntegerT>(i * chunkSize);
+            start = static_cast<IntegerT>(range.start + static_cast<IntegerT>(i * chunkSize));
             thisChunkSize = chunkSize;
           } else {
             // After transition, chunks are smaller by 1
             IntegerT ti = static_cast<IntegerT>(transitionIdx);
             IntegerT ri = static_cast<IntegerT>(idx - transitionIdx);
-            start = range.start + static_cast<IntegerT>(ti * chunkSize) +
-                static_cast<IntegerT>(ri * smallChunkSize);
+            start = static_cast<IntegerT>(
+                range.start + static_cast<IntegerT>(ti * chunkSize) +
+                static_cast<IntegerT>(ri * smallChunkSize));
             thisChunkSize = smallChunkSize;
           }
-          IntegerT end = start + thisChunkSize;
+          IntegerT end = static_cast<IntegerT>(start + thisChunkSize);
 
           auto stateIt = states.begin();
           std::advance(stateIt, static_cast<ptrdiff_t>(idx));
@@ -415,12 +416,13 @@ void parallel_for_staticImpl(
     IntegerT lastStart;
     if (numThreads - 1 < transitionIdx) {
       IntegerT i = static_cast<IntegerT>(numThreads - 1);
-      lastStart = range.start + static_cast<IntegerT>(i * chunkSize);
+      lastStart = static_cast<IntegerT>(range.start + static_cast<IntegerT>(i * chunkSize));
     } else {
       IntegerT ti = static_cast<IntegerT>(transitionIdx);
       IntegerT ri = static_cast<IntegerT>(numThreads - 1 - transitionIdx);
-      lastStart = range.start + static_cast<IntegerT>(ti * chunkSize) +
-          static_cast<IntegerT>(ri * smallChunkSize);
+      lastStart = static_cast<IntegerT>(
+          range.start + static_cast<IntegerT>(ti * chunkSize) +
+          static_cast<IntegerT>(ri * smallChunkSize));
     }
     f(*stateIt, lastStart, range.end);
     taskSet.wait();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,10 @@ macro(package_add_test TEST_NAME LABEL TEST_FILE)
     add_executable(${TEST_NAME} ${TEST_FILE})
     target_compile_options(${TEST_NAME} PRIVATE
       $<$<CXX_COMPILER_ID:MSVC>:/W3 /WX>
+      # GCC 13 false positives: stringop-overflow through deeply inlined atomics,
+      # maybe-uninitialized through inlined try_pop + gtest macros.
+      # GCC 14+ does not trigger these.  Revisit when CI moves off GCC 13.
+      $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,14>>:-Wno-stringop-overflow -Wno-maybe-uninitialized>
       $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -pedantic -Wconversion -Wno-sign-conversion -Werror>
       )
     target_link_libraries(${TEST_NAME} gmock_main dispenso)

--- a/tests/spsc_ring_buffer_test.cpp
+++ b/tests/spsc_ring_buffer_test.cpp
@@ -464,7 +464,7 @@ TEST(SPSCRingBuffer, ConcurrentProducerConsumer) {
   // Consumer thread
   std::thread consumer([&]() {
     int value;
-    while (consumed.size() < kNumItems) {
+    while (consumed.size() < static_cast<size_t>(kNumItems)) {
       if (buffer.try_pop(value)) {
         consumed.push_back(value);
       } else if (producerDone.load(std::memory_order_acquire) && buffer.empty()) {
@@ -505,7 +505,7 @@ TEST(SPSCRingBuffer, ConcurrentWithSmallBuffer) {
 
   std::thread consumer([&]() {
     int value;
-    while (consumed.size() < kNumItems) {
+    while (consumed.size() < static_cast<size_t>(kNumItems)) {
       if (buffer.try_pop(value)) {
         consumed.push_back(value);
       } else if (producerDone.load(std::memory_order_acquire) && buffer.empty()) {
@@ -545,7 +545,7 @@ TEST(SPSCRingBuffer, ConcurrentWithMoveOnlyType) {
 
   std::thread consumer([&]() {
     std::unique_ptr<int> value;
-    while (consumed.size() < kNumItems) {
+    while (consumed.size() < static_cast<size_t>(kNumItems)) {
       if (buffer.try_pop(value)) {
         consumed.push_back(*value);
         value.reset();
@@ -836,7 +836,7 @@ TEST(SPSCRingBuffer, LargeCapacityConcurrent) {
 
   std::thread consumer([&]() {
     int value;
-    while (consumed.size() < kNumItems) {
+    while (consumed.size() < static_cast<size_t>(kNumItems)) {
       if (buffer.try_pop(value)) {
         consumed.push_back(value);
       } else if (producerDone.load(std::memory_order_acquire) && buffer.empty()) {
@@ -1039,7 +1039,7 @@ TEST(SPSCRingBuffer, BatchConcurrent) {
 
   std::thread consumer([&]() {
     std::vector<int> batch(kBatchSize);
-    while (consumed.size() < kNumItems) {
+    while (consumed.size() < static_cast<size_t>(kNumItems)) {
       size_t popped = buffer.try_pop_batch(batch.begin(), kBatchSize);
       if (popped > 0) {
         for (size_t i = 0; i < popped; ++i) {


### PR DESCRIPTION
Summary:

Three categories of CI failures fixed:

1. -Wconversion narrowing in parallel_for.h: When IntegerT is short,
   short+short promotes to int; assigning back to short triggers
   -Werror=conversion. Fixed by wrapping full addition expressions
   in static_cast<IntegerT>(...) at 5 locations.

2. GCC 13 false positive -Wstringop-overflow in atomic_base.h: Known
   GCC bug triggered by deep inlining through template-heavy code.
   Added -Wno-stringop-overflow for GCC in tests/CMakeLists.txt
   (matching existing suppression in dispenso/CMakeLists.txt).

3. MSVC C4018 signed/unsigned mismatch in spsc_ring_buffer_test.cpp:
   vector::size() (size_t) compared with int kNumItems. Fixed with
   static_cast<size_t>(kNumItems) at 5 locations.

Reviewed By: sanchitgarg

Differential Revision: D97560098


