### PR TITLE
Improve code coverage and fix Doxygen links in README (#69)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,9 +196,12 @@ jobs:
       - name: Build
         working-directory: ./build
         run: cmake --build . --parallel 4
-      - name: Test
+      - name: Test (stable tests)
         working-directory: ./build
         run: ctest -LE flaky
+      - name: Test (TimedTask, with retries)
+        working-directory: ./build
+        run: ctest -L flaky -R "^TimedTaskTest\." --repeat until-pass:5
       - name: Generate coverage report
         run: |
           lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch,gcov,negative

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Dispenso is a modern **C++ parallel computing library** that provides work-steal
 Dispenso provides a comprehensive set of parallel programming primitives:
 
 **Core runtime:**
-* **[`ThreadPool`](https://facebookincubator.github.io/dispenso/classdispenso_1_1ThreadPool.html)** — work-stealing thread pool backing all dispenso parallelism
-* **[`TaskSet`](https://facebookincubator.github.io/dispenso/classdispenso_1_1TaskSet.html) / [`ConcurrentTaskSet`](https://facebookincubator.github.io/dispenso/classdispenso_1_1ConcurrentTaskSet.html)** — task grouping with wait, cancellation, and recursive scheduling
+* **[`ThreadPool`](https://facebookincubator.github.io/dispenso/classdispenso_1_1_thread_pool.html)** — work-stealing thread pool backing all dispenso parallelism
+* **[`TaskSet`](https://facebookincubator.github.io/dispenso/classdispenso_1_1_task_set.html) / [`ConcurrentTaskSet`](https://facebookincubator.github.io/dispenso/classdispenso_1_1_concurrent_task_set.html)** — task grouping with wait, cancellation, and recursive scheduling
 
 **Parallel algorithms:**
 * **[`parallel_for`](docs/getting_started.md#your-first-parallel-loop)** — parallel loops over indices, blocking or non-blocking (cascaded); cascading `parallel_for` enables overlapping independent loops without oversubscription
@@ -61,7 +61,7 @@ Dispenso provides a comprehensive set of parallel programming primitives:
 **Concurrent containers and synchronization:**
 * **[`ConcurrentVector`](docs/getting_started.md#concurrentvector)** — concurrent growable vector, superset of TBB `concurrent_vector` API
 * **[`Latch`](docs/getting_started.md#latch)** — one-shot barrier for thread synchronization
-* **[`RWLock`](https://facebookincubator.github.io/dispenso/classdispenso_1_1RWLock.html)** — reader-writer spin lock, outperforms `std::shared_mutex` under low write contention
+* **[`RWLock`](https://facebookincubator.github.io/dispenso/classdispenso_1_1_r_w_lock.html)** — reader-writer spin lock, outperforms `std::shared_mutex` under low write contention
 * **`SPSCRingBuffer`** — lock-free single-producer single-consumer ring buffer *(1.5.0)*
 
 **General-purpose utilities:**

--- a/dispenso/concurrent_vector.h
+++ b/dispenso/concurrent_vector.h
@@ -69,10 +69,12 @@
 // Disabled on ARM where cache-line writes on every growth operation cause store buffer
 // pressure that exceeds the read-path benefit (acquire loads are effectively free for
 // sequential access patterns on ARM).
+#if !defined(DISPENSO_HAS_CACHED_PTRS)
 #if !defined(__aarch64__) && !defined(_M_ARM64)
 #define DISPENSO_HAS_CACHED_PTRS 1
 #else
 #define DISPENSO_HAS_CACHED_PTRS 0
+#endif
 #endif
 
 namespace dispenso {

--- a/tests/concurrent_vector_nocache_test.cpp
+++ b/tests/concurrent_vector_nocache_test.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Force the opposite cache-pointer mode for this platform so CI exercises
+// whichever code path is normally skipped.
+#if !defined(__aarch64__) && !defined(_M_ARM64)
+#define DISPENSO_HAS_CACHED_PTRS 0
+#else
+#define DISPENSO_HAS_CACHED_PTRS 1
+#endif
+
+#include "concurrent_vector_test_common_types.h"
+
+using TestTraitsTypes = ::testing::Types<dispenso::DefaultConcurrentVectorTraits>;
+DISPENSO_DISABLE_WARNING_PUSH
+DISPENSO_DISABLE_WARNING_ZERO_VARIADIC_MACRO_ARGUMENTS
+TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes);
+DISPENSO_DISABLE_WARNING_POP
+
+#include "concurrent_vector_test_common.h"


### PR DESCRIPTION
Summary:

**Coverage improvements** — Dispenso's Codecov target is 92% but CI reports
~91.2-91.4% due to two gaps:

1. `detail/concurrent_vector_impl2.h` has ~60 lines at 0% coverage because
   `DISPENSO_HAS_CACHED_PTRS` is always 1 on x86 (the CI platform). Add a new
   test (`concurrent_vector_nocache_test`) that forces the opposite value of
   the flag before including the header, exercising the non-cached code path
   on x86 and the cached path on ARM. Wrap the macro definition in
   `concurrent_vector.h` with `#ifndef` so it can be overridden.

2. `timed_task.cpp` and `priority.cpp` are at 0% coverage because their tests
   are excluded from CI via `ctest -LE flaky`. Change the coverage job to
   `ctest -E priority_test --repeat until-pass:5` which includes `timed_task_test`
   (timing-flaky but safe with retries) while still excluding `priority_test`
   (requires elevated privileges for `kHigh`/`kRealtime` thread priorities that
   GitHub Actions runners don't have). Other CI jobs keep `ctest -LE flaky`
   unchanged.

**README link fixes** — Doxygen 1.12 changed its output filename convention
from CamelCase (`classdispenso_1_1ThreadPool.html`) to underscore-separated
(`classdispenso_1_1_thread_pool.html`). Update the 4 Doxygen API links in
README.md to match the deployed gh-pages filenames.

Differential Revision: D97831620


