### PR TITLE
Move PoolWakeState wake infra into detail/ and dispenso::detail (#73)

### DIFF
--- a/dispenso/detail/thread_pool_wake.h
+++ b/dispenso/detail/thread_pool_wake.h
@@ -5,15 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/**
- * @file thread_pool_wake.h
- * @ingroup group_core
- * Wake infrastructure for ThreadPool's fork-join and central queue scheduling.
- *
- * Implements a budget-limited cascade wake strategy with per-thread EpochWaiters
- * and per-group atomic sleep masks. See docs/design/wake_cascade.md for the
- * design rationale.
- **/
+// Wake infrastructure for ThreadPool's fork-join and central queue scheduling.
+//
+// Implements a budget-limited cascade wake strategy with per-thread
+// EpochWaiters and per-group atomic sleep masks. See
+// docs/design/wake_cascade.md for the design rationale.
 
 #pragma once
 
@@ -27,6 +23,7 @@
 #include <dispenso/platform.h>
 
 namespace dispenso {
+namespace detail {
 
 // Platform-tunable wake parameters.
 // BranchFactor: max children per node in the wake cascade tree.
@@ -44,66 +41,51 @@ constexpr int32_t kDefaultWakeBranchFactor = 8;
 constexpr int32_t kDefaultWakeBranchFactor = 4;
 #endif
 
-/**
- * @brief Per-group state.
- *
- * `sleepMask`: bit i set when thread i in the group is sleeping on the
- * group's EpochWaiter. Wakers may atomically test-and-clear bits to claim
- * exclusive wake responsibility (e.g. for targeted wakes via
- * `claimAndWakeOne`).
- */
+// Per-group state. sleepMask: bit i set when thread i in the group is sleeping
+// on the group's EpochWaiter. Wakers may atomically test-and-clear bits to
+// claim exclusive wake responsibility (e.g. for targeted wakes via
+// claimAndWakeOne).
 struct DISPENSO_CACHELINE_ALIGNED GroupWakeState {
-  /// Bit i set when thread i in the group is sleeping on the group's EpochWaiter.
   std::atomic<uint64_t> sleepMask{0};
 };
 
-/// Maximum number of threads that share a single wake group (one futex address).
+// Maximum number of threads that share a single wake group (one futex address).
 static constexpr int32_t kMaxThreadsPerWakeGroup = 64;
 
-/**
- * @brief Cache-line-aligned block of EpochWaiters for one group.
- *
- * Each group shares one EpochWaiter (one futex address). The block is
- * cache-line aligned to prevent inter-group false sharing.
- *
- * A single futex_wake(addr, K) wakes K arbitrary threads from the group;
- * futex_wake(addr, 1) wakes one. Bulk wakes for K > groupSize fan out across
- * groups via the Pattern C cascade — workers in the seed group each carry a
- * pre-staged lambda that wakes one target group; level-2 cascade hosts in
- * those groups wake the remaining groups in parallel.
- */
+// Cache-line-aligned block of EpochWaiters for one group. Each group shares one
+// EpochWaiter (one futex address); the block is cache-line aligned to prevent
+// inter-group false sharing.
+//
+// A single futex_wake(addr, K) wakes K arbitrary threads from the group;
+// futex_wake(addr, 1) wakes one. Bulk wakes for K > groupSize fan out across
+// groups via the Pattern C cascade — workers in the seed group each carry a
+// pre-staged lambda that wakes one target group; level-2 cascade hosts in
+// those groups wake the remaining groups in parallel.
 struct DISPENSO_CACHELINE_ALIGNED WaiterBlock {
-  detail::EpochWaiter waiter; ///< The group's shared EpochWaiter (one futex address).
+  detail::EpochWaiter waiter;
 };
 
-/**
- * @class PoolWakeState
- * @brief Wake infrastructure for a ThreadPool.
- *
- * Manages per-thread EpochWaiters, per-group sleep masks, and a static
- * 1-seed 2-level cascade table for fan-out wakes. Used by ThreadPool for
- * both fork-join (per-thread ring dispatch via `cascadeWakeSeed` + cascade
- * lambdas) and central queue (also via `cascadeWakeSeed`) work dispatch.
- *
- * ## Thread Safety
- *
- * - `enterSleep` / `exitSleep`: called only by the owning thread
- * - `tryClaimSleeper`: safe to call from any thread (atomic test-and-clear)
- * - `claimAndWakeOne` / `wakeRange` / `cascadeWakeSeed` / `wakeAll`:
- *   safe to call from any thread
- * - `cascadeWake`: called only from cascade-host lambdas (one per cascade
- *   slot per dispatch)
- */
+// Wake infrastructure for a ThreadPool.
+//
+// Manages per-thread EpochWaiters, per-group sleep masks, and a static
+// 1-seed 2-level cascade table for fan-out wakes. Used by ThreadPool for both
+// fork-join (per-thread ring dispatch via cascadeWakeSeed + cascade lambdas)
+// and central queue (also via cascadeWakeSeed) work dispatch.
+//
+// Thread safety:
+//  - enterSleep / exitSleep: called only by the owning thread
+//  - tryClaimSleeper: safe to call from any thread (atomic test-and-clear)
+//  - claimAndWakeOne / wakeRange / cascadeWakeSeed / wakeAll: safe from any
+//    thread
+//  - cascadeWake: called only from cascade-host lambdas (one per cascade slot
+//    per dispatch)
 class PoolWakeState {
  public:
-  /**
-   * @brief Construct wake state for a pool with the given number of threads.
-   *
-   * @param numThreads Total number of pool worker threads.
-   * @param groupSize Number of threads per wake group (typically 16, matching
-   *                  CpuSet topology groups).
-   * @param branchFactor Maximum children per node in budget cascade.
-   */
+  // Construct wake state for a pool with the given number of threads.
+  //  - numThreads: total number of pool worker threads.
+  //  - groupSize: number of threads per wake group (typically matching CpuSet
+  //    topology groups).
+  //  - branchFactor: maximum children per node in budget cascade.
   DISPENSO_DLL_ACCESS PoolWakeState(
       int32_t numThreads,
 #if defined(DISPENSO_TUNE_WAKE_GROUP_SIZE)
@@ -124,20 +106,15 @@ class PoolWakeState {
   PoolWakeState(const PoolWakeState&) = delete;
   PoolWakeState& operator=(const PoolWakeState&) = delete;
 
-  /**
-   * @brief Get the EpochWaiter for a specific thread's group. All threads
-   * in a group share one EpochWaiter (one futex address); bumpAndWakeN on
-   * this waiter wakes K arbitrary threads from the group with one syscall.
-   */
+  // Get the EpochWaiter for a specific thread's group. All threads in a group
+  // share one EpochWaiter (one futex address); bumpAndWakeN on this waiter
+  // wakes K arbitrary threads from the group with one syscall.
   detail::EpochWaiter& waiterFor(int32_t threadIdx) {
     return waiterBlocks_[static_cast<size_t>(threadIdx / groupSize_)].waiter;
   }
 
-  /**
-   * @brief Mark a thread as sleeping. Called before entering EpochWaiter sleep.
-   *
-   * Sets the thread's bit in its group's sleep mask.
-   */
+  // Mark a thread as sleeping. Called before entering EpochWaiter sleep. Sets
+  // the thread's bit in its group's sleep mask.
   void enterSleep(int32_t threadIdx) {
     int32_t group = threadIdx / groupSize_;
     int32_t bit = threadIdx % groupSize_;
@@ -146,12 +123,9 @@ class PoolWakeState {
     totalSleeping_.fetch_add(1, std::memory_order_relaxed);
   }
 
-  /**
-   * @brief Mark a thread as awake. Called after returning from EpochWaiter sleep.
-   *
-   * Clears the thread's bit in its group's sleep mask. This handles the
-   * timeout-wake case where no waker cleared the bit.
-   */
+  // Mark a thread as awake. Called after returning from EpochWaiter sleep.
+  // Clears the thread's bit in its group's sleep mask. This handles the
+  // timeout-wake case where no waker cleared the bit.
   void exitSleep(int32_t threadIdx) {
     int32_t group = threadIdx / groupSize_;
     int32_t bit = threadIdx % groupSize_;
@@ -160,13 +134,10 @@ class PoolWakeState {
     totalSleeping_.fetch_sub(1, std::memory_order_relaxed);
   }
 
-  /**
-   * @brief Atomically try to claim a sleeping thread for waking.
-   *
-   * @return true if we cleared the bit (we own the wake and should call
-   *         bumpAndWake on the thread's waiter). false if the thread was
-   *         already awake or claimed by another waker.
-   */
+  // Atomically try to claim a sleeping thread for waking. Returns true if we
+  // cleared the bit (we own the wake and should call bumpAndWake on the
+  // thread's waiter); false if the thread was already awake or claimed by
+  // another waker.
   bool tryClaimSleeper(int32_t threadIdx) {
     int32_t group = threadIdx / groupSize_;
     int32_t bit = threadIdx % groupSize_;
@@ -176,51 +147,41 @@ class PoolWakeState {
     return (prev & bitMask) != 0;
   }
 
-  /**
-   * @brief Claim a sleeping thread, wake it, and return its index.
-   *
-   * Proactive wake: atomically claims the sleeper (clears its bit so
-   * subsequent callers see fewer sleepers), bumps its waiter, and returns
-   * the thread index. The caller can then push work directly to that
-   * thread's ring so it's waiting when the thread wakes.
-   *
-   * @return Thread index of the woken thread, or -1 if no sleeping threads.
-   */
+  // Claim a sleeping thread, wake it, and return its index. Proactive wake:
+  // atomically claims the sleeper (clears its bit so subsequent callers see
+  // fewer sleepers), bumps its waiter, and returns the thread index. The
+  // caller can then push work directly to that thread's ring so it's waiting
+  // when the thread wakes. Returns -1 if no sleeping threads.
   DISPENSO_DLL_ACCESS int32_t claimAndWakeOne();
 
-  /**
-   * @brief Wake threads in range [0, count) that are sleeping.
-   *
-   * Serial fork-join wake: for each affected group, bumps the epoch and
-   * issues a futex syscall iff sleepers exist in that group. O(numGroups)
-   * syscalls in the worst case; superseded by `cascadeWakeSeed` for the
-   * default scheduleBulkToRings path. Kept as a fallback when cascade is
-   * disabled at compile time (`-DDISPENSO_DISABLE_CASCADE_WAKERANGE`).
-   */
+  // Wake threads in range [0, count) that are sleeping. Serial fork-join wake:
+  // for each affected group, bumps the epoch and issues a futex syscall iff
+  // sleepers exist in that group. O(numGroups) syscalls in the worst case;
+  // superseded by cascadeWakeSeed for the default scheduleBulkToRings path.
+  // Kept as a fallback when cascade is disabled at compile time
+  // (-DDISPENSO_DISABLE_CASCADE_WAKERANGE).
   DISPENSO_DLL_ACCESS void wakeRange(int32_t count);
 
-  /**
-   * @brief Wake all sleeping threads. Used during shutdown.
-   */
+  // Wake all sleeping threads. Used during shutdown.
   DISPENSO_DLL_ACCESS void wakeAll();
 
-  /** @brief Total number of threads managed by this wake state. */
+  // Total number of threads managed by this wake state.
   int32_t numThreads() const {
     return numThreads_;
   }
-  /** @brief Number of wake groups. */
+  // Number of wake groups.
   int32_t numGroups() const {
     return numGroups_;
   }
-  /** @brief Threads per wake group. */
+  // Threads per wake group.
   int32_t groupSize() const {
     return groupSize_;
   }
-  /** @brief Maximum children per node in the cascade tree. */
+  // Maximum children per node in the cascade tree.
   int32_t branchFactor() const {
     return branchFactor_;
   }
-  /** @brief Number of threads currently sleeping across all groups. */
+  // Number of threads currently sleeping across all groups.
   int32_t totalSleeping() const {
     return totalSleeping_.load(std::memory_order_relaxed);
   }
@@ -243,11 +204,11 @@ class PoolWakeState {
   // 192 threads / G=8 = 24 groups: levels 1+2 cover 1+8 = 9 groups (72
   // threads). Need level 3 for the remaining 15 groups.
 
-  /// Returns the level-2/3 target group for a cascade-host thread, or -1 if
-  /// this thread is not a cascade host OR if the target group lies outside
-  /// the wake range [0, count). The count gate matches scheduleBulkToRings's
-  /// "wake only threads with work" contract: for partial-pool dispatch we
-  /// don't want cascade hosts firing wakes into empty groups.
+  // Returns the level-2/3 target group for a cascade-host thread, or -1 if
+  // this thread is not a cascade host OR if the target group lies outside
+  // the wake range [0, count). The count gate matches scheduleBulkToRings's
+  // "wake only threads with work" contract: for partial-pool dispatch we
+  // don't want cascade hosts firing wakes into empty groups.
   int32_t cascadeTargetFor(int32_t threadIdx, int32_t count) const {
     if (threadIdx < 0 || static_cast<size_t>(threadIdx) >= cascadeTargets_.size()) {
       return -1;
@@ -257,8 +218,8 @@ class PoolWakeState {
     return (target <= lastGroup) ? target : -1;
   }
 
-  /// Wakes one target group: bumps the group's epoch and issues bumpAndWakeN
-  /// only if the sleepMask is non-zero. Called by cascade-host lambdas.
+  // Wakes one target group: bumps the group's epoch and issues bumpAndWakeN
+  // only if the sleepMask is non-zero. Called by cascade-host lambdas.
   void cascadeWake(int32_t targetGroup) {
     uint64_t mask =
         groupStates_[static_cast<size_t>(targetGroup)].sleepMask.load(std::memory_order_relaxed);
@@ -271,9 +232,9 @@ class PoolWakeState {
     }
   }
 
-  /// Single-pass wake for scheduleBulkToRings. Bumps every affected group's
-  /// epoch and wakes seed group g0 if any sleepers exist in [0, count).
-  /// Returns true if the cold path was taken (sleepers found).
+  // Single-pass wake for scheduleBulkToRings. Bumps every affected group's
+  // epoch and wakes seed group g0 if any sleepers exist in [0, count).
+  // Returns true if the cold path was taken (sleepers found).
   DISPENSO_DLL_ACCESS bool cascadeWakeSeed(int32_t count);
 
  private:
@@ -306,4 +267,5 @@ class PoolWakeState {
   int32_t branchFactor_;
 };
 
+} // namespace detail
 } // namespace dispenso

--- a/dispenso/schedulable.cpp
+++ b/dispenso/schedulable.cpp
@@ -5,11 +5,38 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cassert>
 #include <cstdlib>
 
 #include <dispenso/schedulable.h>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 namespace dispenso {
+
+#if defined(_WIN32)
+namespace {
+// Pin the module that physically contains dispenso's code — the .exe, dispenso's own DLL, or a host
+// DLL that statically linked dispenso (FROM_ADDRESS resolves whichever it is) — so it can never be
+// unmapped while a detached NewThreadInvoker thread is still executing inside it. Process-lifetime
+// pin, taken only if NewThreadInvoker is ever actually used. Also covers a host FreeLibrary() at
+// runtime, which the atexit drain cannot. See the rationale block in schedulable.h.
+void pinModuleForNewThread() {
+  HMODULE hmod = nullptr;
+  const BOOL pinned = GetModuleHandleExW(
+      GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+      reinterpret_cast<LPCWSTR>(&pinModuleForNewThread),
+      &hmod);
+  // Pinning our own code address should never fail; if it somehow does we lose the unmap guarantee
+  // that lets the atexit drain be bounded, so surface it loudly in debug builds. Release proceeds
+  // (the bounded wait remains a best-effort safety net).
+  assert(pinned && "Failed to pin dispenso module for NewThreadInvoker");
+  (void)pinned;
+}
+} // namespace
+#endif // _WIN32
 
 NewThreadInvoker::ThreadWaiter* NewThreadInvoker::getWaiter() {
   // Controlled-leak Meyers singleton, mirroring SmallBufferGlobals. The waiter is allocated on
@@ -18,6 +45,9 @@ NewThreadInvoker::ThreadWaiter* NewThreadInvoker::getWaiter() {
   // comment in schedulable.h for why this matters and why we do not delete the waiter at exit.
   static ThreadWaiter* waiter = []() {
     auto* w = new ThreadWaiter();
+#if defined(_WIN32)
+    pinModuleForNewThread();
+#endif
     std::atexit([]() { getWaiter()->wait(); });
     return w;
   }();

--- a/dispenso/schedulable.h
+++ b/dispenso/schedulable.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cassert>
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -112,11 +113,17 @@ class NewThreadInvoker {
   // decRefCountMaybeDestroy + thread-local-storage teardown, which extends past the user-visible
   // future.get() return.
   //
-  // ThreadWaiter blocks the atexit handler until every detached thread has called remove(), so
-  // no thread is mid-execution when _cexit / DLL unload runs. The SmallBufferAllocator
-  // controlled-leak fix (small_buffer_allocator.cpp) addresses a different hazard (returning
-  // small buffers to a destroyed central store) and is NOT a substitute for this. Both
-  // mitigations are needed.
+  // Two mitigations, both needed:
+  //   1. pinModuleForNewThread() (schedulable.cpp, Windows-only) pins the module that contains
+  //      dispenso's code so it is never unmapped while a detached thread is still executing in it.
+  //      This removes the access-violation regardless of how long the thread runs, and also covers
+  //      a host FreeLibrary() at runtime, which the atexit path cannot. (Only Windows eagerly
+  //      unmaps a module's code under a running thread; POSIX/other loaders don't, so no analog.)
+  //   2. ThreadWaiter gives outstanding threads a BOUNDED grace period at exit to reach remove(),
+  //      narrowing the post-future.get() teardown window. It is bounded (never blocks shutdown
+  //      indefinitely) precisely because (1) makes a thread that runs past the deadline non-fatal.
+  // The SmallBufferAllocator controlled-leak fix (small_buffer_allocator.cpp) addresses a separate
+  // hazard (returning small buffers to a destroyed central store) and is also needed.
   //
   // The relevant tests are future_test_sans_exceptions and future_shared_test, the
   // Future.AsyncNotAsyncSpecifyNewThread / NewThreadInvoker / AsyncSpecifyNewThread cases.
@@ -144,7 +151,10 @@ class NewThreadInvoker {
 
     void wait() {
       std::unique_lock<std::mutex> lk(mtx_);
-      cond_.wait(lk, [this]() { return count_ == 0; });
+      // Bounded best-effort: pinModuleForNewThread() keeps our code mapped, so a thread still
+      // running past this deadline cannot fault on unload — this only narrows the teardown window
+      // and must never wedge shutdown, so it times out rather than blocking forever.
+      cond_.wait_for(lk, std::chrono::seconds(2), [this]() { return count_ == 0; });
     }
   };
 

--- a/dispenso/thread_pool.cpp
+++ b/dispenso/thread_pool.cpp
@@ -109,7 +109,7 @@ ThreadPool::ThreadPool(size_t n, size_t poolLoadMultiplier)
     numRings_.store(adjustedN, std::memory_order_release);
     numStealRings_.store(
         (adjustedN + stealRingSharing_ - 1) / stealRingSharing_, std::memory_order_release);
-    auto ws = detail::makeAligned<PoolWakeState>(static_cast<int32_t>(adjustedN));
+    auto ws = detail::makeAligned<detail::PoolWakeState>(static_cast<int32_t>(adjustedN));
     auto* rawWs = ws.get();
     wakeStateGraveyard_.push_back(std::move(ws));
     DISPENSO_TSAN_ANNOTATE_HAPPENS_BEFORE(&wakeState_);
@@ -344,7 +344,7 @@ void ThreadPool::resizeLocked(ssize_t sn) {
     }
     numStealRings_.store(newNumSteal, std::memory_order_release);
 
-    auto newWake = detail::makeAligned<PoolWakeState>(static_cast<int32_t>(n));
+    auto newWake = detail::makeAligned<detail::PoolWakeState>(static_cast<int32_t>(n));
     auto* rawNewWake = newWake.get();
     // Retained for the lifetime of the pool — never freed here. Freeing a retired
     // PoolWakeState would race a concurrent lock-free schedule() that still holds

--- a/dispenso/thread_pool.h
+++ b/dispenso/thread_pool.h
@@ -29,10 +29,10 @@
 #include <dispenso/cpu_set.h>
 #include <dispenso/detail/math.h>
 #include <dispenso/detail/per_thread_info.h>
+#include <dispenso/detail/thread_pool_wake.h>
 #include <dispenso/mpmc_ring_buffer.h>
 #include <dispenso/once_function.h>
 #include <dispenso/platform.h>
-#include <dispenso/thread_pool_wake.h>
 #include <dispenso/tsan_annotations.h>
 
 namespace dispenso {
@@ -559,8 +559,8 @@ class DISPENSO_CACHELINE_ALIGNED ThreadPool {
   // accumulate meaningful memory. See docs/design/roadmap.md ("Bounded
   // PoolWakeState reclamation") for the planned asymmetric-fence / hazard-pointer
   // scheme to bound this without taxing the schedule() hot path.
-  std::atomic<PoolWakeState*> wakeState_{nullptr};
-  std::vector<decltype(detail::makeAligned<PoolWakeState>(0))> wakeStateGraveyard_;
+  std::atomic<detail::PoolWakeState*> wakeState_{nullptr};
+  std::vector<decltype(detail::makeAligned<detail::PoolWakeState>(0))> wakeStateGraveyard_;
 
   // Per-thread rings for fork-join scheduling. ConcurrentObjectArena provides
   // stable pointers (grow-only, never freed), eliminating the need for a resize

--- a/dispenso/thread_pool_wake.cpp
+++ b/dispenso/thread_pool_wake.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <dispenso/thread_pool_wake.h>
+#include <dispenso/detail/thread_pool_wake.h>
 
 #include <dispenso/detail/math.h>
 
@@ -13,6 +13,7 @@
 #include <cassert>
 
 namespace dispenso {
+namespace detail {
 
 PoolWakeState::PoolWakeState(int32_t numThreads, int32_t groupSize, int32_t branchFactor)
     : numThreads_(numThreads),
@@ -186,4 +187,5 @@ void PoolWakeState::wakeAll() {
   }
 }
 
+} // namespace detail
 } // namespace dispenso

--- a/tests/thread_pool_wake_test.cpp
+++ b/tests/thread_pool_wake_test.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <dispenso/thread_pool_wake.h>
+#include <dispenso/detail/thread_pool_wake.h>
 
 #include <atomic>
 #include <thread>
@@ -13,7 +13,7 @@
 
 #include <gtest/gtest.h>
 
-using dispenso::PoolWakeState;
+using dispenso::detail::PoolWakeState;
 
 // =============================================================================
 // Construction Tests


### PR DESCRIPTION
Summary:

`thread_pool_wake.h` is purely internal wake machinery (`PoolWakeState`, `GroupWakeState`, `WaiterBlock`, cascade tables), but it lived in the public `dispenso/` header dir and `namespace dispenso`, so Doxygen — which scans `dispenso/*.h` non-recursively — required public doc comments for every member (the source of the recent OSS Documentation-check failures). Move the header to `dispenso/detail/` and put all symbols in `namespace dispenso::detail` so it falls outside the Doxygen input entirely; internal types no longer need public API docs. Drop the now-unnecessary doxygen comments, keeping the explanations as plain comments.

The `.cpp` stays in place (BUCK lists it by path) but its contents move into `dispenso::detail`. Consumers (`thread_pool.h`, `thread_pool.cpp`, `thread_pool_wake_test.cpp`) now qualify `detail::PoolWakeState`. No BUCK edit needed: the header globs (`dispenso/*.h` -> public, `dispenso/detail/*.h` -> raw) pick up the new location automatically, matching the existing `detail/par_for_stripe.h` pattern (a detail header included by a public header).

Differential Revision: D107779288
