### PR TITLE
Pin module for NewThreadInvoker; bound the shutdown drain (fix rare Windows hang) (#74)

### DIFF
--- a/dispenso/schedulable.cpp
+++ b/dispenso/schedulable.cpp
@@ -5,11 +5,38 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <cassert>
 #include <cstdlib>
 
 #include <dispenso/schedulable.h>
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 namespace dispenso {
+
+#if defined(_WIN32)
+namespace {
+// Pin the module that physically contains dispenso's code — the .exe, dispenso's own DLL, or a host
+// DLL that statically linked dispenso (FROM_ADDRESS resolves whichever it is) — so it can never be
+// unmapped while a detached NewThreadInvoker thread is still executing inside it. Process-lifetime
+// pin, taken only if NewThreadInvoker is ever actually used. Also covers a host FreeLibrary() at
+// runtime, which the atexit drain cannot. See the rationale block in schedulable.h.
+void pinModuleForNewThread() {
+  HMODULE hmod = nullptr;
+  const BOOL pinned = GetModuleHandleExW(
+      GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN,
+      reinterpret_cast<LPCWSTR>(&pinModuleForNewThread),
+      &hmod);
+  // Pinning our own code address should never fail; if it somehow does we lose the unmap guarantee
+  // that lets the atexit drain be bounded, so surface it loudly in debug builds. Release proceeds
+  // (the bounded wait remains a best-effort safety net).
+  assert(pinned && "Failed to pin dispenso module for NewThreadInvoker");
+  (void)pinned;
+}
+} // namespace
+#endif // _WIN32
 
 NewThreadInvoker::ThreadWaiter* NewThreadInvoker::getWaiter() {
   // Controlled-leak Meyers singleton, mirroring SmallBufferGlobals. The waiter is allocated on
@@ -18,6 +45,9 @@ NewThreadInvoker::ThreadWaiter* NewThreadInvoker::getWaiter() {
   // comment in schedulable.h for why this matters and why we do not delete the waiter at exit.
   static ThreadWaiter* waiter = []() {
     auto* w = new ThreadWaiter();
+#if defined(_WIN32)
+    pinModuleForNewThread();
+#endif
     std::atexit([]() { getWaiter()->wait(); });
     return w;
   }();

--- a/dispenso/schedulable.h
+++ b/dispenso/schedulable.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cassert>
+#include <chrono>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
@@ -112,11 +113,17 @@ class NewThreadInvoker {
   // decRefCountMaybeDestroy + thread-local-storage teardown, which extends past the user-visible
   // future.get() return.
   //
-  // ThreadWaiter blocks the atexit handler until every detached thread has called remove(), so
-  // no thread is mid-execution when _cexit / DLL unload runs. The SmallBufferAllocator
-  // controlled-leak fix (small_buffer_allocator.cpp) addresses a different hazard (returning
-  // small buffers to a destroyed central store) and is NOT a substitute for this. Both
-  // mitigations are needed.
+  // Two mitigations, both needed:
+  //   1. pinModuleForNewThread() (schedulable.cpp, Windows-only) pins the module that contains
+  //      dispenso's code so it is never unmapped while a detached thread is still executing in it.
+  //      This removes the access-violation regardless of how long the thread runs, and also covers
+  //      a host FreeLibrary() at runtime, which the atexit path cannot. (Only Windows eagerly
+  //      unmaps a module's code under a running thread; POSIX/other loaders don't, so no analog.)
+  //   2. ThreadWaiter gives outstanding threads a BOUNDED grace period at exit to reach remove(),
+  //      narrowing the post-future.get() teardown window. It is bounded (never blocks shutdown
+  //      indefinitely) precisely because (1) makes a thread that runs past the deadline non-fatal.
+  // The SmallBufferAllocator controlled-leak fix (small_buffer_allocator.cpp) addresses a separate
+  // hazard (returning small buffers to a destroyed central store) and is also needed.
   //
   // The relevant tests are future_test_sans_exceptions and future_shared_test, the
   // Future.AsyncNotAsyncSpecifyNewThread / NewThreadInvoker / AsyncSpecifyNewThread cases.
@@ -144,7 +151,10 @@ class NewThreadInvoker {
 
     void wait() {
       std::unique_lock<std::mutex> lk(mtx_);
-      cond_.wait(lk, [this]() { return count_ == 0; });
+      // Bounded best-effort: pinModuleForNewThread() keeps our code mapped, so a thread still
+      // running past this deadline cannot fault on unload — this only narrows the teardown window
+      // and must never wedge shutdown, so it times out rather than blocking forever.
+      cond_.wait_for(lk, std::chrono::seconds(2), [this]() { return count_ == 0; });
     }
   };
 


### PR DESCRIPTION
Summary:

NewThreadInvoker spawns a detached std::thread per call and relies on an atexit ThreadWaiter to block process exit until each thread finishes, which prevents the Windows DLL-unload-under-running-thread crash. But blocking forever in atexit turns that rare crash into a rare shutdown hang (seen on the Windows x86 future tests): if a detached thread doesn't reach remove() in time — or the wait runs under the loader lock during DLL_PROCESS_DETACH — process exit wedges.

Fix the hazard at its root rather than blocking on it. Pin the module that physically contains dispenso's code via GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN, ...). FROM_ADDRESS resolves the correct module whether dispenso is statically linked into the .exe, built as its own DLL, or statically linked into a host DLL — the compile-time DISPENSO_SHARED_LIB flag cannot see that last case, so this is done at runtime. Pinning keeps the code mapped for the process lifetime, so a detached thread still running at shutdown can no longer fault on unmap, and it additionally covers a host FreeLibrary() at runtime, which the atexit path never could. The pin is taken once, lazily, only if NewThreadInvoker is actually used.

With the unmap hazard removed, the atexit drain becomes a bounded best-effort (wait_for 2s) that can never wedge shutdown again. Windows-only: only the Windows PE loader eagerly unmaps a module's code while a thread runs in it; POSIX and other loaders do not, so there is no analog to add.

Differential Revision: D107779289


