### PR TITLE
Add initial FreeBSD support for thread-pool wake and CpuSet affinity queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### New features
 * **`ChaseLevDeque`** — lock-free single-producer multi-consumer work-stealing deque with dynamic resizing. Classic data structure for work-stealing schedulers.
 * **`MpmcRingBuffer`** — bounded multi-producer multi-consumer ring buffer with power-of-two capacity and CAS-based push/pop.
-* **`CpuSet`** — portable CPU affinity and NUMA topology facility. Supports thread-to-core binding, L2/L3 cache group detection, and cache-aware thread group building. Full support on Linux and Windows; topology-only on macOS.
+* **`CpuSet`** — portable CPU affinity and NUMA topology facility. Supports thread-to-core binding, L2/L3 cache group detection, and cache-aware thread group building. Full support on Linux, Windows, and FreeBSD; topology-only on macOS.
 * **`parallel_invoke`** — fork-join invocation of heterogeneous tasks. Schedules N-1 tasks to the pool and runs the last inline. Composes naturally with recursive divide-and-conquer.
 * **`kAdaptive` parallel_for** — new chunking strategy inspired by Callisto-RTS (Harris/Kaestle, USENIX ATC 2015). The iteration space is partitioned into P contiguous stripes (one per worker), each consumed front-to-back via per-stripe atomic cursors. When a worker's stripe is exhausted, it steals from peers, preferring same-L3 victims for cache locality. Bitmasks prevent probing exhausted stripes. Competitive with TBB on SpMM benchmarks (3–12% faster at 8–32 threads, within noise at 64–192 threads on 1M-row workloads).
 * **`when_any` combinator** — returns a future that completes when any input future is ready, with the index of the first completed future.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,13 @@ cmake PATH_TO_DISPENSO_ROOT
 make -j
 ```
 
+**FreeBSD:**
+```bash
+mkdir build && cd build
+cmake PATH_TO_DISPENSO_ROOT
+cmake --build . --parallel $(sysctl -n hw.ncpu)
+```
+
 **Windows** (from Developer Command Prompt):
 ```bash
 mkdir build && cd build

--- a/dispenso/cpu_set.cpp
+++ b/dispenso/cpu_set.cpp
@@ -102,6 +102,91 @@ CpuSet parseLinuxCpuList(const char* input) {
   return set;
 }
 
+// Parses FreeBSD's kern.sched.topology_spec XML for the given cache level
+// (2 = L2, 3 = L3). Pure string parsing, so it compiles and is unit-tested on
+// every platform; parseCacheGroups() feeds it the sysctl output on FreeBSD.
+// Groups are returned sorted by first CPU id.
+std::vector<CacheGroup> parseCacheGroupsFromTopologySpec(const std::string& xml, int cacheIndex) {
+  std::vector<CacheGroup> groups;
+  size_t pos = 0;
+  int nextCacheId = 0;
+  while ((pos = xml.find("<group", pos)) != std::string::npos) {
+    size_t startPos = pos;
+    size_t endGroupTag = xml.find(">", pos);
+    if (endGroupTag == std::string::npos) break;
+    pos = endGroupTag + 1;
+
+    size_t cacheLevelPos = xml.find("cache-level=\"", startPos);
+    if (cacheLevelPos != std::string::npos && cacheLevelPos < endGroupTag) {
+      cacheLevelPos += 13; // past `cache-level="`
+      size_t cacheLevelEnd = xml.find("\"", cacheLevelPos);
+      if (cacheLevelEnd != std::string::npos && cacheLevelEnd < endGroupTag) {
+        size_t levelLen = cacheLevelEnd - cacheLevelPos;
+        int32_t cacheLevel = -1;
+        if (levelLen < 8) {
+          char levelBuf[8];
+          std::memcpy(levelBuf, xml.c_str() + cacheLevelPos, levelLen);
+          levelBuf[levelLen] = '\0';
+          cacheLevel = parseIntClamped(levelBuf);
+        }
+
+        if (cacheLevel == cacheIndex) {
+          size_t cpuPos = xml.find("<cpu", pos);
+          if (cpuPos == std::string::npos) continue;
+
+          // Take only this group's own <cpu>, not one from a nested child group.
+          size_t nextGroupPos = xml.find("<group", pos);
+          size_t closeGroupPos = xml.find("</group>", pos);
+          if (nextGroupPos != std::string::npos && nextGroupPos < cpuPos) {
+            continue;
+          }
+          if (closeGroupPos != std::string::npos && closeGroupPos < cpuPos) {
+            continue;
+          }
+
+          size_t cpuTagEnd = xml.find(">", cpuPos);
+          if (cpuTagEnd == std::string::npos) continue;
+          size_t cpuClose = xml.find("</cpu>", cpuTagEnd);
+          if (cpuClose == std::string::npos) continue;
+
+          const char* xmlStart = xml.c_str();
+          const char* p = xmlStart + cpuTagEnd + 1;
+          const char* endPtr = xmlStart + cpuClose;
+          std::vector<int32_t> cpus;
+          while (p < endPtr) {
+            while (p < endPtr && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\r' || *p == '\n')) {
+              p++;
+            }
+            if (p >= endPtr) break;
+
+            char* parsedEnd = nullptr;
+            long val = std::strtol(p, &parsedEnd, 10);
+            if (parsedEnd == p) {
+              break;
+            }
+            if (val >= 0 && val <= kMaxReasonableCpuId) {
+              cpus.push_back(static_cast<int32_t>(val));
+            }
+            p = parsedEnd;
+          }
+
+          if (!cpus.empty()) {
+            CacheGroup g;
+            g.cpus = std::move(cpus);
+            g.cacheId = nextCacheId++;
+            groups.push_back(std::move(g));
+            pos = cpuClose + 6; // past `</cpu>`
+          }
+        }
+      }
+    }
+  }
+  std::sort(groups.begin(), groups.end(), [](const CacheGroup& a, const CacheGroup& b) {
+    return a.cpus.front() < b.cpus.front();
+  });
+  return groups;
+}
+
 } // namespace detail
 
 // =============================================================================
@@ -382,7 +467,6 @@ bool readCacheCpuList(
 // Parses L2 or L3 cache sharing groups (Linux sysfs, FreeBSD kern.sched.topology_spec).
 // cacheIndex: 2 for L2, 3 for L3
 std::vector<CacheGroup> parseCacheGroups(int cacheIndex) {
-  (void)cacheIndex;
   std::vector<CacheGroup> groups;
 #if defined(__linux__)
   char indexStr[8];
@@ -426,85 +510,9 @@ std::vector<CacheGroup> parseCacheGroups(int cacheIndex) {
     std::vector<char> buf(len);
     if (sysctlbyname("kern.sched.topology_spec", buf.data(), &len, nullptr, 0) == 0 && len > 0) {
       buf[len - 1] = '\0';
-      std::string xml(buf.data());
-      size_t pos = 0;
-      int nextCacheId = 0;
-      while ((pos = xml.find("<group", pos)) != std::string::npos) {
-        size_t startPos = pos;
-        size_t endGroupTag = xml.find(">", pos);
-        if (endGroupTag == std::string::npos) break;
-        pos = endGroupTag + 1;
-
-        size_t cacheLevelPos = xml.find("cache-level=\"", startPos);
-        if (cacheLevelPos != std::string::npos && cacheLevelPos < endGroupTag) {
-          cacheLevelPos += 13; // past `cache-level="`
-          size_t cacheLevelEnd = xml.find("\"", cacheLevelPos);
-          if (cacheLevelEnd != std::string::npos && cacheLevelEnd < endGroupTag) {
-            size_t levelLen = cacheLevelEnd - cacheLevelPos;
-            int32_t cacheLevel = -1;
-            if (levelLen < 8) {
-              char levelBuf[8];
-              std::memcpy(levelBuf, xml.c_str() + cacheLevelPos, levelLen);
-              levelBuf[levelLen] = '\0';
-              cacheLevel = detail::parseIntClamped(levelBuf);
-            }
-
-            if (cacheLevel == cacheIndex) {
-              size_t cpuPos = xml.find("<cpu", pos);
-              if (cpuPos == std::string::npos) continue;
-
-              // Take only this group's own <cpu>, not one from a nested child group.
-              size_t nextGroupPos = xml.find("<group", pos);
-              size_t closeGroupPos = xml.find("</group>", pos);
-              if (nextGroupPos != std::string::npos && nextGroupPos < cpuPos) {
-                continue;
-              }
-              if (closeGroupPos != std::string::npos && closeGroupPos < cpuPos) {
-                continue;
-              }
-
-              size_t cpuTagEnd = xml.find(">", cpuPos);
-              if (cpuTagEnd == std::string::npos) continue;
-              size_t cpuClose = xml.find("</cpu>", cpuTagEnd);
-              if (cpuClose == std::string::npos) continue;
-
-              const char* xmlStart = xml.c_str();
-              const char* p = xmlStart + cpuTagEnd + 1;
-              const char* endPtr = xmlStart + cpuClose;
-              std::vector<int32_t> cpus;
-              while (p < endPtr) {
-                while (p < endPtr && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\r' || *p == '\n')) {
-                  p++;
-                }
-                if (p >= endPtr) break;
-
-                char* parsedEnd = nullptr;
-                long val = std::strtol(p, &parsedEnd, 10);
-                if (parsedEnd == p) {
-                  break;
-                }
-                if (val >= 0 && val <= detail::kMaxReasonableCpuId) {
-                  cpus.push_back(static_cast<int32_t>(val));
-                }
-                p = parsedEnd;
-              }
-
-              if (!cpus.empty()) {
-                CacheGroup g;
-                g.cpus = std::move(cpus);
-                g.cacheId = nextCacheId++;
-                groups.push_back(std::move(g));
-                pos = cpuClose + 6; // past `</cpu>`
-              }
-            }
-          }
-        }
-      }
+      groups = detail::parseCacheGroupsFromTopologySpec(std::string(buf.data()), cacheIndex);
     }
   }
-  std::sort(groups.begin(), groups.end(), [](const CacheGroup& a, const CacheGroup& b) {
-    return a.cpus.front() < b.cpus.front();
-  });
 #endif // __linux__
   return groups;
 }

--- a/dispenso/cpu_set.cpp
+++ b/dispenso/cpu_set.cpp
@@ -113,7 +113,8 @@ std::vector<CacheGroup> parseCacheGroupsFromTopologySpec(const std::string& xml,
   while ((pos = xml.find("<group", pos)) != std::string::npos) {
     size_t startPos = pos;
     size_t endGroupTag = xml.find(">", pos);
-    if (endGroupTag == std::string::npos) break;
+    if (endGroupTag == std::string::npos)
+      break;
     pos = endGroupTag + 1;
 
     size_t cacheLevelPos = xml.find("cache-level=\"", startPos);
@@ -132,7 +133,8 @@ std::vector<CacheGroup> parseCacheGroupsFromTopologySpec(const std::string& xml,
 
         if (cacheLevel == cacheIndex) {
           size_t cpuPos = xml.find("<cpu", pos);
-          if (cpuPos == std::string::npos) continue;
+          if (cpuPos == std::string::npos)
+            continue;
 
           // Take only this group's own <cpu>, not one from a nested child group.
           size_t nextGroupPos = xml.find("<group", pos);
@@ -145,19 +147,23 @@ std::vector<CacheGroup> parseCacheGroupsFromTopologySpec(const std::string& xml,
           }
 
           size_t cpuTagEnd = xml.find(">", cpuPos);
-          if (cpuTagEnd == std::string::npos) continue;
+          if (cpuTagEnd == std::string::npos)
+            continue;
           size_t cpuClose = xml.find("</cpu>", cpuTagEnd);
-          if (cpuClose == std::string::npos) continue;
+          if (cpuClose == std::string::npos)
+            continue;
 
           const char* xmlStart = xml.c_str();
           const char* p = xmlStart + cpuTagEnd + 1;
           const char* endPtr = xmlStart + cpuClose;
           std::vector<int32_t> cpus;
           while (p < endPtr) {
-            while (p < endPtr && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\r' || *p == '\n')) {
+            while (p < endPtr &&
+                   (*p == ' ' || *p == ',' || *p == '\t' || *p == '\r' || *p == '\n')) {
               p++;
             }
-            if (p >= endPtr) break;
+            if (p >= endPtr)
+              break;
 
             char* parsedEnd = nullptr;
             long val = std::strtol(p, &parsedEnd, 10);

--- a/dispenso/cpu_set.cpp
+++ b/dispenso/cpu_set.cpp
@@ -173,8 +173,9 @@ bool CpuSet::bindCurrentThread() const {
 }
 
 int32_t CpuSet::currentHardwareThread() {
-#if defined(__linux__)
-  // sched_getcpu() uses the vDSO on modern kernels (~15 ns, no syscall).
+#if defined(__linux__) || (defined(__FreeBSD__) && __FreeBSD_version >= 1301000)
+  // Linux: sched_getcpu() uses the vDSO on modern kernels (~15 ns, no syscall).
+  // FreeBSD (13.1+): sched_getcpu() is a syscall.
   int cpu = sched_getcpu();
   return (cpu >= 0) ? static_cast<int32_t>(cpu) : -1;
 #else
@@ -188,6 +189,7 @@ int32_t CpuSet::currentHardwareThread() {
 
 namespace {
 
+#if defined(__linux__)
 // Read a small file into a NUL-terminated buffer. Returns empty string on failure.
 std::vector<char> readSmallFile(int dirFd, const char* path) {
   int fd = ::openat(dirFd, path, O_RDONLY);
@@ -226,7 +228,9 @@ std::vector<char> readSmallFile(int dirFd, const char* path) {
   buf.resize(static_cast<size_t>(totalRead) + 1);
   return buf;
 }
+#endif
 
+#if defined(__linux__)
 // Parse a "nodeN" sysfs directory name, returning the node index, or -1.
 int32_t parseNodeDirName(const char* name) {
   if (name[0] != 'n' || name[1] != 'o' || name[2] != 'd' || name[3] != 'e' || name[4] == '\0') {
@@ -234,6 +238,7 @@ int32_t parseNodeDirName(const char* name) {
   }
   return detail::parseIntClamped(name + 4);
 }
+#endif
 
 const std::vector<CpuSet>& getNumaSets() {
   static const std::vector<CpuSet> numaSets = []() {
@@ -354,6 +359,7 @@ bool readCacheCpuList(
 // Parses L2 or L3 cache sharing groups from sysfs.
 // cacheIndex: 2 for L2, 3 for L3
 std::vector<CacheGroup> parseCacheGroups(int cacheIndex) {
+  (void)cacheIndex;
   std::vector<CacheGroup> groups;
 #if defined(__linux__)
   char indexStr[8];
@@ -854,6 +860,11 @@ int32_t CpuSet::availableCount() {
 #if defined(__linux__)
   cpu_set_t mask;
   if (sched_getaffinity(0, sizeof(mask), &mask) == 0) {
+    return static_cast<int32_t>(CPU_COUNT(&mask));
+  }
+#elif defined(__FreeBSD__)
+  cpu_set_t mask;
+  if (cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(mask), &mask) == 0) {
     return static_cast<int32_t>(CPU_COUNT(&mask));
   }
 #elif defined(_WIN32)

--- a/dispenso/cpu_set.cpp
+++ b/dispenso/cpu_set.cpp
@@ -28,6 +28,10 @@
 #include <unistd.h>
 #endif // __linux__
 
+#if defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#endif
+
 #if defined(__APPLE__)
 #include <dlfcn.h>
 
@@ -184,7 +188,7 @@ int32_t CpuSet::currentHardwareThread() {
 }
 
 // =============================================================================
-// NUMA topology detection (Linux)
+// NUMA topology detection (Linux, FreeBSD)
 // =============================================================================
 
 namespace {
@@ -267,6 +271,25 @@ const std::vector<CpuSet>& getNumaSets() {
         }
       }
       ::closedir(nodeDir);
+    }
+#elif defined(__FreeBSD__)
+    int ndomains = 0;
+    size_t len = sizeof(ndomains);
+    if (sysctlbyname("vm.ndomains", &ndomains, &len, nullptr, 0) == 0 && ndomains > 0) {
+      for (int i = 0; i < ndomains; ++i) {
+        cpu_set_t mask;
+        if (cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_DOMAIN, i, sizeof(mask), &mask) == 0) {
+          CpuSet s;
+          for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+            if (CPU_ISSET(cpu, &mask)) {
+              s.add(cpu);
+            }
+          }
+          if (s.count() > 0) {
+            sets.push_back(std::move(s));
+          }
+        }
+      }
     }
 #endif // __linux__
     // Fallback: if no NUMA nodes were found (missing sysfs, container, etc.),
@@ -356,7 +379,7 @@ bool readCacheCpuList(
 
 #endif // __linux__
 
-// Parses L2 or L3 cache sharing groups from sysfs.
+// Parses L2 or L3 cache sharing groups (Linux sysfs, FreeBSD kern.sched.topology_spec).
 // cacheIndex: 2 for L2, 3 for L3
 std::vector<CacheGroup> parseCacheGroups(int cacheIndex) {
   (void)cacheIndex;
@@ -393,6 +416,91 @@ std::vector<CacheGroup> parseCacheGroups(int cacheIndex) {
   groups.reserve(byId.size());
   for (auto& kv : byId) {
     groups.push_back(std::move(kv.second));
+  }
+  std::sort(groups.begin(), groups.end(), [](const CacheGroup& a, const CacheGroup& b) {
+    return a.cpus.front() < b.cpus.front();
+  });
+#elif defined(__FreeBSD__)
+  size_t len = 0;
+  if (sysctlbyname("kern.sched.topology_spec", nullptr, &len, nullptr, 0) == 0 && len > 0) {
+    std::vector<char> buf(len);
+    if (sysctlbyname("kern.sched.topology_spec", buf.data(), &len, nullptr, 0) == 0 && len > 0) {
+      buf[len - 1] = '\0';
+      std::string xml(buf.data());
+      size_t pos = 0;
+      int nextCacheId = 0;
+      while ((pos = xml.find("<group", pos)) != std::string::npos) {
+        size_t startPos = pos;
+        size_t endGroupTag = xml.find(">", pos);
+        if (endGroupTag == std::string::npos) break;
+        pos = endGroupTag + 1;
+
+        size_t cacheLevelPos = xml.find("cache-level=\"", startPos);
+        if (cacheLevelPos != std::string::npos && cacheLevelPos < endGroupTag) {
+          cacheLevelPos += 13; // past `cache-level="`
+          size_t cacheLevelEnd = xml.find("\"", cacheLevelPos);
+          if (cacheLevelEnd != std::string::npos && cacheLevelEnd < endGroupTag) {
+            size_t levelLen = cacheLevelEnd - cacheLevelPos;
+            int32_t cacheLevel = -1;
+            if (levelLen < 8) {
+              char levelBuf[8];
+              std::memcpy(levelBuf, xml.c_str() + cacheLevelPos, levelLen);
+              levelBuf[levelLen] = '\0';
+              cacheLevel = detail::parseIntClamped(levelBuf);
+            }
+
+            if (cacheLevel == cacheIndex) {
+              size_t cpuPos = xml.find("<cpu", pos);
+              if (cpuPos == std::string::npos) continue;
+
+              // Take only this group's own <cpu>, not one from a nested child group.
+              size_t nextGroupPos = xml.find("<group", pos);
+              size_t closeGroupPos = xml.find("</group>", pos);
+              if (nextGroupPos != std::string::npos && nextGroupPos < cpuPos) {
+                continue;
+              }
+              if (closeGroupPos != std::string::npos && closeGroupPos < cpuPos) {
+                continue;
+              }
+
+              size_t cpuTagEnd = xml.find(">", cpuPos);
+              if (cpuTagEnd == std::string::npos) continue;
+              size_t cpuClose = xml.find("</cpu>", cpuTagEnd);
+              if (cpuClose == std::string::npos) continue;
+
+              const char* xmlStart = xml.c_str();
+              const char* p = xmlStart + cpuTagEnd + 1;
+              const char* endPtr = xmlStart + cpuClose;
+              std::vector<int32_t> cpus;
+              while (p < endPtr) {
+                while (p < endPtr && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\r' || *p == '\n')) {
+                  p++;
+                }
+                if (p >= endPtr) break;
+
+                char* parsedEnd = nullptr;
+                long val = std::strtol(p, &parsedEnd, 10);
+                if (parsedEnd == p) {
+                  break;
+                }
+                if (val >= 0 && val <= detail::kMaxReasonableCpuId) {
+                  cpus.push_back(static_cast<int32_t>(val));
+                }
+                p = parsedEnd;
+              }
+
+              if (!cpus.empty()) {
+                CacheGroup g;
+                g.cpus = std::move(cpus);
+                g.cacheId = nextCacheId++;
+                groups.push_back(std::move(g));
+                pos = cpuClose + 6; // past `</cpu>`
+              }
+            }
+          }
+        }
+      }
+    }
   }
   std::sort(groups.begin(), groups.end(), [](const CacheGroup& a, const CacheGroup& b) {
     return a.cpus.front() < b.cpus.front();

--- a/dispenso/cpu_set.cpp
+++ b/dispenso/cpu_set.cpp
@@ -102,90 +102,102 @@ CpuSet parseLinuxCpuList(const char* input) {
   return set;
 }
 
-// Parses FreeBSD's kern.sched.topology_spec XML for the given cache level
-// (2 = L2, 3 = L3). Pure string parsing, so it compiles and is unit-tested on
-// every platform; parseCacheGroups() feeds it the sysctl output on FreeBSD.
-// Groups are returned sorted by first CPU id.
+namespace {
+
+constexpr char kCacheLevelAttr[] = "cache-level=\"";
+constexpr size_t kCacheLevelAttrLen = sizeof(kCacheLevelAttr) - 1;
+constexpr char kCpuCloseTag[] = "</cpu>";
+constexpr size_t kCpuCloseTagLen = sizeof(kCpuCloseTag) - 1;
+
+// Parse the cache-level attribute within a group's opening tag [tagStart,
+// tagEnd), returning -1 if absent or malformed.
+int32_t parseGroupCacheLevel(const std::string& xml, size_t tagStart, size_t tagEnd) {
+  size_t attrPos = xml.find(kCacheLevelAttr, tagStart);
+  if (attrPos == std::string::npos || attrPos >= tagEnd) {
+    return -1;
+  }
+  attrPos += kCacheLevelAttrLen;
+  size_t attrEnd = xml.find('"', attrPos);
+  if (attrEnd == std::string::npos || attrEnd >= tagEnd) {
+    return -1;
+  }
+  // strtol stops at the first non-digit, so this cannot read past the closing quote.
+  return parseIntClamped(xml.c_str() + attrPos);
+}
+
+// Parse the group's own <cpu>...</cpu> id list, with `pos` just past the
+// group's opening tag; a nested child group's <cpu> is not consumed.
+// Advances `pos` past </cpu> only when ids were parsed.
+std::vector<int32_t> parseGroupOwnCpuList(const std::string& xml, size_t& pos) {
+  std::vector<int32_t> cpus;
+  size_t cpuPos = xml.find("<cpu", pos);
+  if (cpuPos == std::string::npos) {
+    return cpus;
+  }
+  // Take only this group's own <cpu>, not one from a nested child group.
+  if (xml.find("<group", pos) < cpuPos || xml.find("</group>", pos) < cpuPos) {
+    return cpus;
+  }
+  size_t cpuTagEnd = xml.find('>', cpuPos);
+  if (cpuTagEnd == std::string::npos) {
+    return cpus;
+  }
+  size_t cpuClose = xml.find(kCpuCloseTag, cpuTagEnd);
+  if (cpuClose == std::string::npos) {
+    return cpus;
+  }
+
+  const char* p = xml.c_str() + cpuTagEnd + 1;
+  const char* endPtr = xml.c_str() + cpuClose;
+  while (p < endPtr) {
+    while (p < endPtr && (*p == ' ' || *p == ',' || *p == '\t' || *p == '\r' || *p == '\n')) {
+      p++;
+    }
+    if (p >= endPtr) {
+      break;
+    }
+    char* parsedEnd = nullptr;
+    long val = std::strtol(p, &parsedEnd, 10);
+    if (parsedEnd == p) {
+      break;
+    }
+    if (val >= 0 && val <= kMaxReasonableCpuId) {
+      cpus.push_back(static_cast<int32_t>(val));
+    }
+    p = parsedEnd;
+  }
+
+  if (!cpus.empty()) {
+    pos = cpuClose + kCpuCloseTagLen;
+  }
+  return cpus;
+}
+
+} // namespace
+
 std::vector<CacheGroup> parseCacheGroupsFromTopologySpec(const std::string& xml, int cacheIndex) {
   std::vector<CacheGroup> groups;
   size_t pos = 0;
   int nextCacheId = 0;
   while ((pos = xml.find("<group", pos)) != std::string::npos) {
-    size_t startPos = pos;
-    size_t endGroupTag = xml.find(">", pos);
-    if (endGroupTag == std::string::npos)
+    size_t tagStart = pos;
+    size_t tagEnd = xml.find('>', pos);
+    if (tagEnd == std::string::npos) {
       break;
-    pos = endGroupTag + 1;
-
-    size_t cacheLevelPos = xml.find("cache-level=\"", startPos);
-    if (cacheLevelPos != std::string::npos && cacheLevelPos < endGroupTag) {
-      cacheLevelPos += 13; // past `cache-level="`
-      size_t cacheLevelEnd = xml.find("\"", cacheLevelPos);
-      if (cacheLevelEnd != std::string::npos && cacheLevelEnd < endGroupTag) {
-        size_t levelLen = cacheLevelEnd - cacheLevelPos;
-        int32_t cacheLevel = -1;
-        if (levelLen < 8) {
-          char levelBuf[8];
-          std::memcpy(levelBuf, xml.c_str() + cacheLevelPos, levelLen);
-          levelBuf[levelLen] = '\0';
-          cacheLevel = parseIntClamped(levelBuf);
-        }
-
-        if (cacheLevel == cacheIndex) {
-          size_t cpuPos = xml.find("<cpu", pos);
-          if (cpuPos == std::string::npos)
-            continue;
-
-          // Take only this group's own <cpu>, not one from a nested child group.
-          size_t nextGroupPos = xml.find("<group", pos);
-          size_t closeGroupPos = xml.find("</group>", pos);
-          if (nextGroupPos != std::string::npos && nextGroupPos < cpuPos) {
-            continue;
-          }
-          if (closeGroupPos != std::string::npos && closeGroupPos < cpuPos) {
-            continue;
-          }
-
-          size_t cpuTagEnd = xml.find(">", cpuPos);
-          if (cpuTagEnd == std::string::npos)
-            continue;
-          size_t cpuClose = xml.find("</cpu>", cpuTagEnd);
-          if (cpuClose == std::string::npos)
-            continue;
-
-          const char* xmlStart = xml.c_str();
-          const char* p = xmlStart + cpuTagEnd + 1;
-          const char* endPtr = xmlStart + cpuClose;
-          std::vector<int32_t> cpus;
-          while (p < endPtr) {
-            while (p < endPtr &&
-                   (*p == ' ' || *p == ',' || *p == '\t' || *p == '\r' || *p == '\n')) {
-              p++;
-            }
-            if (p >= endPtr)
-              break;
-
-            char* parsedEnd = nullptr;
-            long val = std::strtol(p, &parsedEnd, 10);
-            if (parsedEnd == p) {
-              break;
-            }
-            if (val >= 0 && val <= kMaxReasonableCpuId) {
-              cpus.push_back(static_cast<int32_t>(val));
-            }
-            p = parsedEnd;
-          }
-
-          if (!cpus.empty()) {
-            CacheGroup g;
-            g.cpus = std::move(cpus);
-            g.cacheId = nextCacheId++;
-            groups.push_back(std::move(g));
-            pos = cpuClose + 6; // past `</cpu>`
-          }
-        }
-      }
     }
+    pos = tagEnd + 1;
+
+    if (parseGroupCacheLevel(xml, tagStart, tagEnd) != cacheIndex) {
+      continue;
+    }
+    std::vector<int32_t> cpus = parseGroupOwnCpuList(xml, pos);
+    if (cpus.empty()) {
+      continue;
+    }
+    CacheGroup g;
+    g.cpus = std::move(cpus);
+    g.cacheId = nextCacheId++;
+    groups.push_back(std::move(g));
   }
   std::sort(groups.begin(), groups.end(), [](const CacheGroup& a, const CacheGroup& b) {
     return a.cpus.front() < b.cpus.front();

--- a/dispenso/cpu_set.h
+++ b/dispenso/cpu_set.h
@@ -15,7 +15,7 @@
  *
  * Platform support:
  * - **Linux**: Full support (binding via pthread_setaffinity_np, topology via sysfs)
- * - **FreeBSD**: Binding supported (cpuset_setaffinity), topology detection deferred
+ * - **FreeBSD**: Full support (binding via pthread_setaffinity_np, topology via sysctl)
  * - **macOS**: Topology query only (binding is not supported by the OS)
  * - **Windows**: Full support (binding via SetThreadGroupAffinity, topology via
  *   GetLogicalProcessorInformationEx)
@@ -54,8 +54,12 @@ typedef cpuset_t cpu_set_t;
 // macOS does not support explicit CPU pinning. bindCurrentThread() is a no-op and
 // returns false. Topology queries return a single-node fallback.
 //
-// FreeBSD binding support is present (cpuset_setaffinity uses a similar interface to
-// Linux), but topology detection requires test hardware and is deferred.
+// FreeBSD binding uses pthread_setaffinity_np (same interface as Linux). NUMA and
+// L2/L3 cache topology are detected via sysctl (vm.ndomains, kern.sched.topology_spec).
+// Cache-group detection depends on the kernel populating cache levels in
+// kern.sched.topology_spec; on topologies where it does not, l2CacheGroups()/
+// l3CacheGroups() return empty and buildThreadGroups() falls back to contiguous
+// chunking. See SMP(4) for the topology_spec format.
 
 /**
  * @brief Compile-time override for the default maximum threads per scheduling group.
@@ -213,8 +217,10 @@ class CpuSet {
   /**
    * @brief Returns the CPU ID of the calling thread's current core.
    *
-   * On Linux, uses the vDSO-accelerated getcpu(). On unsupported platforms,
-   * returns -1.
+   * On Linux, uses the vDSO-accelerated getcpu(); on FreeBSD 13.1+, uses
+   * sched_getcpu(); on Windows, GetCurrentProcessorNumberEx(); on macOS, the
+   * private _os_cpu_number(). On platforms without CPU-query support (including
+   * FreeBSD older than 13.1), returns -1.
    *
    * @note The result is instantaneous and may be stale by the time it is used
    *       (the OS may migrate the thread). Useful as a hint for scheduling
@@ -267,6 +273,8 @@ class CpuSet {
    * @brief Returns the number of hardware threads available to this process.
    *
    * On Linux, queries the process CPU affinity mask (respects taskset/cgroup).
+   * On FreeBSD, queries the calling thread's cpuset affinity mask via
+   * cpuset_getaffinity (respects cpuset(1) restrictions).
    * On Windows single-group systems, queries the process affinity mask.
    * On Windows multi-group systems, sums active processors per group (does not
    * reflect process-level restrictions).

--- a/dispenso/cpu_set.h
+++ b/dispenso/cpu_set.h
@@ -55,12 +55,10 @@ typedef cpuset_t cpu_set_t;
 // macOS does not support explicit CPU pinning. bindCurrentThread() is a no-op and
 // returns false. Topology queries return a single-node fallback.
 //
-// FreeBSD binding uses pthread_setaffinity_np (same interface as Linux). NUMA and
-// L2/L3 cache topology are detected via sysctl (vm.ndomains, kern.sched.topology_spec).
-// Cache-group detection depends on the kernel populating cache levels in
-// kern.sched.topology_spec; on topologies where it does not, l2CacheGroups()/
-// l3CacheGroups() return empty and buildThreadGroups() falls back to contiguous
-// chunking. See SMP(4) for the topology_spec format.
+// FreeBSD binding uses pthread_setaffinity_np, as on Linux. NUMA and cache
+// topology are read from sysctl (vm.ndomains, kern.sched.topology_spec); when
+// the kernel reports no cache levels, cache group queries return empty and
+// buildThreadGroups() falls back to contiguous chunking.
 
 /**
  * @brief Compile-time override for the default maximum threads per scheduling group.

--- a/dispenso/cpu_set.h
+++ b/dispenso/cpu_set.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -384,6 +385,16 @@ namespace detail {
  * This is an internal helper exposed for testing.
  */
 DISPENSO_DLL_ACCESS CpuSet parseLinuxCpuList(const char* input);
+
+/**
+ * @brief Parses FreeBSD's kern.sched.topology_spec XML into the cache sharing
+ * groups at the given level (2 = L2, 3 = L3), sorted by first CPU id.
+ *
+ * Pure string parsing with no platform APIs; exposed for testing.
+ */
+DISPENSO_DLL_ACCESS std::vector<CacheGroup> parseCacheGroupsFromTopologySpec(
+    const std::string& xml,
+    int cacheIndex);
 } // namespace detail
 
 } // namespace dispenso

--- a/dispenso/cpu_set.h
+++ b/dispenso/cpu_set.h
@@ -40,9 +40,9 @@
 #include <pthread.h>
 #include <sched.h>
 #if defined(__FreeBSD__)
-#include <sys/param.h>
-#include <sys/cpuset.h>
 #include <pthread_np.h>
+#include <sys/cpuset.h>
+#include <sys/param.h>
 typedef cpuset_t cpu_set_t;
 #endif
 #elif defined(_WIN32)

--- a/dispenso/cpu_set.h
+++ b/dispenso/cpu_set.h
@@ -203,6 +203,10 @@ class CpuSet {
    * On Linux/FreeBSD, calls pthread_setaffinity_np. On unsupported platforms
    * (macOS, Windows without GROUP_AFFINITY support), returns false.
    *
+   * @note On FreeBSD, a mask containing nonexistent CPU ids fails with EINVAL,
+   *       whereas Linux intersects the mask with the online CPUs. Include only
+   *       real CPU ids for portable behavior.
+   *
    * @return true if binding succeeded, false on failure or unsupported platform.
    */
   DISPENSO_DLL_ACCESS bool bindCurrentThread() const;

--- a/dispenso/cpu_set.h
+++ b/dispenso/cpu_set.h
@@ -38,6 +38,12 @@
 #if defined(DISPENSO_CPUSET_LINUXY)
 #include <pthread.h>
 #include <sched.h>
+#if defined(__FreeBSD__)
+#include <sys/param.h>
+#include <sys/cpuset.h>
+#include <pthread_np.h>
+typedef cpuset_t cpu_set_t;
+#endif
 #elif defined(_WIN32)
 #define DISPENSO_CPUSET_WINDOWS
 #endif // supported os

--- a/dispenso/detail/completion_event_impl.h
+++ b/dispenso/detail/completion_event_impl.h
@@ -29,7 +29,7 @@
 namespace dispenso {
 namespace detail {
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 
 class CompletionEventImpl {
  public:

--- a/dispenso/detail/epoch_waiter.h
+++ b/dispenso/detail/epoch_waiter.h
@@ -30,7 +30,7 @@ namespace detail {
 // -DDISPENSO_TUNE_WAKE_ALL_THRESHOLD=N.
 #if defined(DISPENSO_TUNE_WAKE_ALL_THRESHOLD)
 constexpr int kWakeAllThreshold = DISPENSO_TUNE_WAKE_ALL_THRESHOLD;
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
 // Single-syscall exact-K — no threshold needed.
 constexpr int kWakeAllThreshold = std::numeric_limits<int>::max();
 #elif defined(__APPLE__)
@@ -46,7 +46,7 @@ constexpr int kWakeAllThreshold = 3;
 constexpr int kWakeAllThreshold = std::numeric_limits<int>::max();
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 
 class EpochWaiter {
  public:

--- a/dispenso/detail/notifier_common.h
+++ b/dispenso/detail/notifier_common.h
@@ -74,9 +74,8 @@ static int futex(
           &t);
     }
   } else if (futex_op == FUTEX_WAKE_PRIVATE) {
-    // NB: unlike Linux futex(FUTEX_WAKE), _umtx_op returns 0 on success rather than
-    // the number of threads woken. `val` still caps how many are woken (INT_MAX wakes
-    // all), so exact-K wake works; callers must not rely on the return value as a count.
+    // Unlike Linux futex(FUTEX_WAKE), _umtx_op returns 0 on success rather than
+    // the count of threads woken; `val` still caps how many are woken.
     return _umtx_op(uaddr, UMTX_OP_WAKE_PRIVATE, static_cast<u_long>(val), nullptr, nullptr);
   }
   errno = ENOTSUP;

--- a/dispenso/detail/notifier_common.h
+++ b/dispenso/detail/notifier_common.h
@@ -77,12 +77,7 @@ static int futex(
     // NB: unlike Linux futex(FUTEX_WAKE), _umtx_op returns 0 on success rather than
     // the number of threads woken. `val` still caps how many are woken (INT_MAX wakes
     // all), so exact-K wake works; callers must not rely on the return value as a count.
-    return _umtx_op(
-        uaddr,
-        UMTX_OP_WAKE_PRIVATE,
-        static_cast<u_long>(val),
-        nullptr,
-        nullptr);
+    return _umtx_op(uaddr, UMTX_OP_WAKE_PRIVATE, static_cast<u_long>(val), nullptr, nullptr);
   }
   errno = ENOTSUP;
   return -1;

--- a/dispenso/detail/notifier_common.h
+++ b/dispenso/detail/notifier_common.h
@@ -54,8 +54,13 @@ static int futex(
     int val3) {
   (void)val3;
   if (futex_op == FUTEX_WAIT_PRIVATE) {
+    // Zero-extend the compare value: the kernel compares the 32-bit value at
+    // uaddr zero-extended against the full u_long val, so sign-extending values
+    // with bit 31 set (e.g. epochs past 2^31) would never match and the wait
+    // would return immediately instead of sleeping.
+    const u_long uval = static_cast<uint32_t>(val);
     if (timeout == nullptr) {
-      return _umtx_op(uaddr, UMTX_OP_WAIT_UINT_PRIVATE, static_cast<u_long>(val), nullptr, nullptr);
+      return _umtx_op(uaddr, UMTX_OP_WAIT_UINT_PRIVATE, uval, nullptr, nullptr);
     } else {
       struct _umtx_time t;
       t._timeout = *timeout;
@@ -64,7 +69,7 @@ static int futex(
       return _umtx_op(
           uaddr,
           UMTX_OP_WAIT_UINT_PRIVATE,
-          static_cast<u_long>(val),
+          uval,
           reinterpret_cast<void*>(static_cast<uintptr_t>(sizeof(t))),
           &t);
     }

--- a/dispenso/detail/notifier_common.h
+++ b/dispenso/detail/notifier_common.h
@@ -31,6 +31,60 @@ static int futex(
 } // namespace detail
 } // namespace dispenso
 
+#elif defined(__FreeBSD__)
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/umtx.h>
+
+#ifndef FUTEX_WAIT_PRIVATE
+#define FUTEX_WAIT_PRIVATE 128
+#endif
+#ifndef FUTEX_WAKE_PRIVATE
+#define FUTEX_WAKE_PRIVATE 129
+#endif
+
+namespace dispenso {
+namespace detail {
+static int futex(
+    int* uaddr,
+    int futex_op,
+    int val,
+    const struct timespec* timeout,
+    int* /*uaddr2*/,
+    int val3) {
+  (void)val3;
+  if (futex_op == FUTEX_WAIT_PRIVATE) {
+    if (timeout == nullptr) {
+      return _umtx_op(uaddr, UMTX_OP_WAIT_UINT_PRIVATE, static_cast<u_long>(val), nullptr, nullptr);
+    } else {
+      struct _umtx_time t;
+      t._timeout = *timeout;
+      t._flags = 0; // relative timeout
+      t._clockid = CLOCK_MONOTONIC;
+      return _umtx_op(
+          uaddr,
+          UMTX_OP_WAIT_UINT_PRIVATE,
+          static_cast<u_long>(val),
+          reinterpret_cast<void*>(static_cast<uintptr_t>(sizeof(t))),
+          &t);
+    }
+  } else if (futex_op == FUTEX_WAKE_PRIVATE) {
+    // NB: unlike Linux futex(FUTEX_WAKE), _umtx_op returns 0 on success rather than
+    // the number of threads woken. `val` still caps how many are woken (INT_MAX wakes
+    // all), so exact-K wake works; callers must not rely on the return value as a count.
+    return _umtx_op(
+        uaddr,
+        UMTX_OP_WAKE_PRIVATE,
+        static_cast<u_long>(val),
+        nullptr,
+        nullptr);
+  }
+  errno = ENOTSUP;
+  return -1;
+}
+} // namespace detail
+} // namespace dispenso
+
 #elif defined(__MACH__)
 #include <Availability.h>
 #include <errno.h>

--- a/dispenso/priority.cpp
+++ b/dispenso/priority.cpp
@@ -159,7 +159,9 @@ bool setCurrentThreadPriority(ThreadPriority prio) {
   return true;
 }
 #elif defined(__FreeBSD__)
-// TODO: Find someone who has a FreeBSD system to test this code.
+// Tested on FreeBSD 15.1. kLow/kNormal/kHigh all use RTP_PRIO_NORMAL (recomputed
+// by ULE), so only kRealtime is meaningfully differentiated. IDLE/REALTIME would
+// separate them but require privilege and IDLE starves under load, so keep NORMAL.
 bool setCurrentThreadPriority(ThreadPriority prio) {
   struct rtprio rtp;
 

--- a/dispenso/thread_pool.h
+++ b/dispenso/thread_pool.h
@@ -61,7 +61,7 @@ class FutureImplBase;
 } // namespace detail
 
 #if !defined(DISPENSO_WAKEUP_ENABLE)
-#if defined(_WIN32) || defined(__linux__) || defined(__MACH__)
+#if defined(_WIN32) || defined(__linux__) || defined(__MACH__) || defined(__FreeBSD__)
 #define DISPENSO_WAKEUP_ENABLE 1
 #else
 #define DISPENSO_WAKEUP_ENABLE 0

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -64,7 +64,7 @@ for detailed cross-platform comparisons, or the
 | Linux x86_64/ARM64 | Full | Full | Full (sysfs) | futex |
 | macOS ARM64/x86_64 | Full | No (OS limitation) | Full | os_sync_wait / ulock |
 | Windows x86_64/ARM64 | Full | Full | Full | WaitOnAddress |
-| FreeBSD | Full | Full (cpuset) | Planned | Planned |
+| FreeBSD | Full | Full (cpuset) | Full (sysctl) | _umtx_op |
 | Android ARM64 | Full | Partial | Partial | futex |
 
 ## What C++ standard does dispenso require?

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -399,7 +399,7 @@ pinSet.bindCurrentThread();
 See [full example](../examples/cpu_set_example.cpp).
 
 Key points:
-- Works on Linux (full support), Windows (full support), macOS (topology only)
+- Works on Linux (full support), Windows (full support), FreeBSD (full support), macOS (topology only)
 - `CpuSet::l2CacheGroups()` / `l3CacheGroups()` return CPU groups that share cache levels
 - Use for NUMA-aware thread placement and cache-friendly scheduling
 

--- a/tests/concurrent_vector_a_test.cpp
+++ b/tests/concurrent_vector_a_test.cpp
@@ -10,7 +10,7 @@
 using TestTraitsTypes = ::testing::Types<TestTraitsA>;
 DISPENSO_DISABLE_WARNING_PUSH
 DISPENSO_DISABLE_WARNING_ZERO_VARIADIC_MACRO_ARGUMENTS
-TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes);
+TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes, );
 DISPENSO_DISABLE_WARNING_POP
 
 #include "concurrent_vector_test_common.h"

--- a/tests/concurrent_vector_b_test.cpp
+++ b/tests/concurrent_vector_b_test.cpp
@@ -10,7 +10,7 @@
 using TestTraitsTypes = ::testing::Types<TestTraitsB>;
 DISPENSO_DISABLE_WARNING_PUSH
 DISPENSO_DISABLE_WARNING_ZERO_VARIADIC_MACRO_ARGUMENTS
-TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes);
+TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes, );
 DISPENSO_DISABLE_WARNING_POP
 
 #include "concurrent_vector_test_common.h"

--- a/tests/concurrent_vector_default_test.cpp
+++ b/tests/concurrent_vector_default_test.cpp
@@ -10,7 +10,7 @@
 using TestTraitsTypes = ::testing::Types<dispenso::DefaultConcurrentVectorTraits>;
 DISPENSO_DISABLE_WARNING_PUSH
 DISPENSO_DISABLE_WARNING_ZERO_VARIADIC_MACRO_ARGUMENTS
-TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes);
+TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes, );
 DISPENSO_DISABLE_WARNING_POP
 
 #include "concurrent_vector_test_common.h"

--- a/tests/concurrent_vector_nocache_test.cpp
+++ b/tests/concurrent_vector_nocache_test.cpp
@@ -18,7 +18,7 @@
 using TestTraitsTypes = ::testing::Types<dispenso::DefaultConcurrentVectorTraits>;
 DISPENSO_DISABLE_WARNING_PUSH
 DISPENSO_DISABLE_WARNING_ZERO_VARIADIC_MACRO_ARGUMENTS
-TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes);
+TYPED_TEST_SUITE(ConcurrentVectorTest, TestTraitsTypes, );
 DISPENSO_DISABLE_WARNING_POP
 
 #include "concurrent_vector_test_common.h"

--- a/tests/cpu_set_test.cpp
+++ b/tests/cpu_set_test.cpp
@@ -304,9 +304,10 @@ TEST(CpuSet, AllSetCoversAllNodeSets) {
 
 TEST(CpuSet, CurrentHardwareThreadIsValid) {
   int32_t cpu = CpuSet::currentHardwareThread();
-#if defined(__linux__) || defined(_WIN32)
-  // Linux (sched_getcpu) and Windows (GetCurrentProcessorNumberEx) both report
-  // a valid hardware thread that must be a member of the full CPU set.
+#if defined(__linux__) || defined(_WIN32) || defined(__FreeBSD__)
+  // Linux (sched_getcpu), Windows (GetCurrentProcessorNumberEx), and FreeBSD
+  // (sched_getcpu, 13.1+) report a valid hardware thread that must be a member
+  // of the full CPU set.
   EXPECT_GE(cpu, 0);
   EXPECT_TRUE(CpuSet::all().contains(cpu));
 #elif defined(__APPLE__)

--- a/tests/cpu_set_test.cpp
+++ b/tests/cpu_set_test.cpp
@@ -112,14 +112,13 @@ TEST(CpuSet, ParseTrailingComma) {
 // =============================================================================
 // FreeBSD topology_spec Parsing Tests
 //
-// These drive the pure string parser directly with synthetic kern.sched.
-// topology_spec XML, so the nested / multi-socket paths are covered on every
-// platform -- not just on whatever topology the test host happens to expose.
+// These drive the parser directly with synthetic kern.sched.topology_spec XML,
+// so nested and multi-socket paths are covered on every platform.
 // =============================================================================
 
 using dispenso::detail::parseCacheGroupsFromTopologySpec;
 
-// Flat single-L3, no L2 -- the shape FreeBSD 15.1 arm64 (4 cores) actually emits.
+// Flat single L3 and no L2, the shape a 4-core FreeBSD 15.1 arm64 machine emits.
 TEST(CpuSet, TopologySpecFlatL3) {
   const std::string xml = R"(<groups>
  <group level="1" cache-level="3">
@@ -224,6 +223,50 @@ TEST(CpuSet, TopologySpecMalformedIsSafe) {
                   .empty());
   // Group tag itself never closed.
   EXPECT_TRUE(parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"", 3).empty());
+}
+
+// One input per defensive early-out in the parser.
+TEST(CpuSet, TopologySpecDefensiveBranches) {
+  // cache-level attribute quote is never closed.
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec("<group cache-level=\"3><cpu>1</cpu>", 3).empty());
+  // Matching group with no <cpu> element at all.
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"></group>", 3).empty());
+  // The only <cpu> belongs to a nested child group, not the matching parent.
+  {
+    const std::string xml = R"(<group cache-level="3">
+ <children>
+  <group cache-level="2">
+   <cpu count="1" mask="1">0</cpu>
+  </group>
+ </children>
+</group>)";
+    EXPECT_TRUE(parseCacheGroupsFromTopologySpec(xml, 3).empty());
+    auto l2 = parseCacheGroupsFromTopologySpec(xml, 2);
+    ASSERT_EQ(l2.size(), 1u);
+    EXPECT_EQ(l2[0].cpus, (std::vector<int32_t>{0}));
+  }
+  // Matching group closes before a stray <cpu> that is not its own.
+  EXPECT_TRUE(
+      parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"></group><cpu>5</cpu>", 3).empty());
+  // <cpu tag never closed with '>'.
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"><cpu", 3).empty());
+  // Trailing separators after the last id.
+  {
+    auto g = parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"><cpu>1, </cpu>", 3);
+    ASSERT_EQ(g.size(), 1u);
+    EXPECT_EQ(g[0].cpus, (std::vector<int32_t>{1}));
+  }
+  // Non-numeric id list.
+  EXPECT_TRUE(
+      parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"><cpu>abc</cpu>", 3).empty());
+}
+
+// A zero-padded cache-level value parses by numeric value, regardless of width.
+TEST(CpuSet, TopologySpecPaddedCacheLevel) {
+  auto g = parseCacheGroupsFromTopologySpec(
+      "<group cache-level=\"00000003\"><cpu count=\"1\" mask=\"2\">1</cpu></group>", 3);
+  ASSERT_EQ(g.size(), 1u);
+  EXPECT_EQ(g[0].cpus, (std::vector<int32_t>{1}));
 }
 
 // =============================================================================

--- a/tests/cpu_set_test.cpp
+++ b/tests/cpu_set_test.cpp
@@ -110,6 +110,123 @@ TEST(CpuSet, ParseTrailingComma) {
 }
 
 // =============================================================================
+// FreeBSD topology_spec Parsing Tests
+//
+// These drive the pure string parser directly with synthetic kern.sched.
+// topology_spec XML, so the nested / multi-socket paths are covered on every
+// platform -- not just on whatever topology the test host happens to expose.
+// =============================================================================
+
+using dispenso::detail::parseCacheGroupsFromTopologySpec;
+
+// Flat single-L3, no L2 -- the shape FreeBSD 15.1 arm64 (4 cores) actually emits.
+TEST(CpuSet, TopologySpecFlatL3) {
+  const std::string xml = R"(<groups>
+ <group level="1" cache-level="3">
+  <cpu count="4" mask="f,0,0,0">0, 1, 2, 3</cpu>
+ </group>
+</groups>)";
+  auto l3 = parseCacheGroupsFromTopologySpec(xml, 3);
+  ASSERT_EQ(l3.size(), 1u);
+  EXPECT_EQ(l3[0].cpus, (std::vector<int32_t>{0, 1, 2, 3}));
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec(xml, 2).empty());
+}
+
+// L3 over two L2 sibling groups: the matching group's own <cpu> must be taken,
+// not a nested child's, and both nested L2 groups must be found.
+TEST(CpuSet, TopologySpecNestedL3OverL2) {
+  const std::string xml = R"(<groups>
+ <group level="1" cache-level="3">
+  <cpu count="4" mask="f">0, 1, 2, 3</cpu>
+  <children>
+   <group level="2" cache-level="2">
+    <cpu count="2" mask="3">0, 1</cpu>
+   </group>
+   <group level="2" cache-level="2">
+    <cpu count="2" mask="c">2, 3</cpu>
+   </group>
+  </children>
+ </group>
+</groups>)";
+  auto l3 = parseCacheGroupsFromTopologySpec(xml, 3);
+  ASSERT_EQ(l3.size(), 1u);
+  EXPECT_EQ(l3[0].cpus, (std::vector<int32_t>{0, 1, 2, 3}));
+
+  auto l2 = parseCacheGroupsFromTopologySpec(xml, 2);
+  ASSERT_EQ(l2.size(), 2u);
+  EXPECT_EQ(l2[0].cpus, (std::vector<int32_t>{0, 1}));
+  EXPECT_EQ(l2[1].cpus, (std::vector<int32_t>{2, 3}));
+}
+
+// Two sockets: top group shares no cache (cache-level=0), each socket an L3.
+TEST(CpuSet, TopologySpecMultiSocketL3) {
+  const std::string xml = R"(<groups>
+ <group level="1" cache-level="0">
+  <cpu count="8" mask="ff">0, 1, 2, 3, 4, 5, 6, 7</cpu>
+  <children>
+   <group level="2" cache-level="3">
+    <cpu count="4" mask="f">0, 1, 2, 3</cpu>
+   </group>
+   <group level="2" cache-level="3">
+    <cpu count="4" mask="f0">4, 5, 6, 7</cpu>
+   </group>
+  </children>
+ </group>
+</groups>)";
+  auto l3 = parseCacheGroupsFromTopologySpec(xml, 3);
+  ASSERT_EQ(l3.size(), 2u);
+  EXPECT_EQ(l3[0].cpus, (std::vector<int32_t>{0, 1, 2, 3}));
+  EXPECT_EQ(l3[1].cpus, (std::vector<int32_t>{4, 5, 6, 7}));
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec(xml, 2).empty());
+}
+
+// Groups emitted out of CPU order must come back sorted by first CPU id.
+TEST(CpuSet, TopologySpecSortsByFirstCpu) {
+  const std::string xml = R"(<groups>
+ <group level="1" cache-level="2">
+  <cpu count="2" mask="30">4, 5</cpu>
+ </group>
+ <group level="1" cache-level="2">
+  <cpu count="2" mask="3">0, 1</cpu>
+ </group>
+</groups>)";
+  auto l2 = parseCacheGroupsFromTopologySpec(xml, 2);
+  ASSERT_EQ(l2.size(), 2u);
+  EXPECT_EQ(l2[0].cpus, (std::vector<int32_t>{0, 1}));
+  EXPECT_EQ(l2[1].cpus, (std::vector<int32_t>{4, 5}));
+}
+
+// Kernel reports no cache levels (cf. the SMP(4) example): both queries empty.
+TEST(CpuSet, TopologySpecNoMatchingCacheLevel) {
+  const std::string xml = R"(<groups>
+ <group level="1" cache-level="0">
+  <cpu count="4" mask="f">0, 1, 2, 3</cpu>
+  <children>
+   <group level="2" cache-level="0">
+    <cpu count="2" mask="3">0, 1</cpu>
+   </group>
+   <group level="2" cache-level="0">
+    <cpu count="2" mask="c">2, 3</cpu>
+   </group>
+  </children>
+ </group>
+</groups>)";
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec(xml, 2).empty());
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec(xml, 3).empty());
+}
+
+// Empty, non-XML, and truncated inputs must not crash and yield no groups.
+TEST(CpuSet, TopologySpecMalformedIsSafe) {
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec("", 3).empty());
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec("not xml at all", 3).empty());
+  // Matching group but the CPU list is never closed with </cpu>.
+  EXPECT_TRUE(
+      parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"><cpu count=\"2\">0, 1", 3).empty());
+  // Group tag itself never closed.
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"", 3).empty());
+}
+
+// =============================================================================
 // CpuSet Manipulation Tests
 // =============================================================================
 

--- a/tests/cpu_set_test.cpp
+++ b/tests/cpu_set_test.cpp
@@ -335,6 +335,13 @@ TEST(CpuSet, L2GroupsAreNonEmpty) {
   for (const auto& group : l2Groups) {
     EXPECT_GT(group.cpus.size(), 0u) << "L2 group with cacheId=" << group.cacheId << " has no CPUs";
   }
+#elif defined(__FreeBSD__)
+  if (l2Groups.empty()) {
+    GTEST_SKIP() << "No L2 cache groups detected on this FreeBSD machine";
+  }
+  for (const auto& group : l2Groups) {
+    EXPECT_GT(group.cpus.size(), 0u) << "L2 group with cacheId=" << group.cacheId << " has no CPUs";
+  }
 #else
   // On unsupported platforms (e.g. macOS), l2CacheGroups() returns empty
   EXPECT_TRUE(l2Groups.empty());
@@ -346,6 +353,13 @@ TEST(CpuSet, L3GroupsAreNonEmpty) {
 #if defined(__linux__) || defined(_WIN32)
   EXPECT_GT(l3Groups.size(), 0u) << "No L3 cache groups detected";
 
+  for (const auto& group : l3Groups) {
+    EXPECT_GT(group.cpus.size(), 0u) << "L3 group with cacheId=" << group.cacheId << " has no CPUs";
+  }
+#elif defined(__FreeBSD__)
+  if (l3Groups.empty()) {
+    GTEST_SKIP() << "No L3 cache groups detected on this FreeBSD machine";
+  }
   for (const auto& group : l3Groups) {
     EXPECT_GT(group.cpus.size(), 0u) << "L3 group with cacheId=" << group.cacheId << " has no CPUs";
   }

--- a/tests/cpu_set_test.cpp
+++ b/tests/cpu_set_test.cpp
@@ -304,7 +304,7 @@ TEST(CpuSet, AllSetCoversAllNodeSets) {
 
 TEST(CpuSet, CurrentHardwareThreadIsValid) {
   int32_t cpu = CpuSet::currentHardwareThread();
-#if defined(__linux__) || defined(_WIN32) || defined(__FreeBSD__)
+#if defined(__linux__) || defined(_WIN32) || (defined(__FreeBSD__) && __FreeBSD_version >= 1301000)
   // Linux (sched_getcpu), Windows (GetCurrentProcessorNumberEx), and FreeBSD
   // (sched_getcpu, 13.1+) report a valid hardware thread that must be a member
   // of the full CPU set.

--- a/tests/cpu_set_test.cpp
+++ b/tests/cpu_set_test.cpp
@@ -220,8 +220,8 @@ TEST(CpuSet, TopologySpecMalformedIsSafe) {
   EXPECT_TRUE(parseCacheGroupsFromTopologySpec("", 3).empty());
   EXPECT_TRUE(parseCacheGroupsFromTopologySpec("not xml at all", 3).empty());
   // Matching group but the CPU list is never closed with </cpu>.
-  EXPECT_TRUE(
-      parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"><cpu count=\"2\">0, 1", 3).empty());
+  EXPECT_TRUE(parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"><cpu count=\"2\">0, 1", 3)
+                  .empty());
   // Group tag itself never closed.
   EXPECT_TRUE(parseCacheGroupsFromTopologySpec("<group cache-level=\"3\"", 3).empty());
 }

--- a/tools/wake_cost_bench.cpp
+++ b/tools/wake_cost_bench.cpp
@@ -186,6 +186,8 @@ static int64_t measure_spurious_round_trip() {
 int main() {
 #ifdef __linux__
   printf("Platform: Linux (futex_wake supports exact K → kWakeAllThreshold = INT_MAX)\n");
+#elif defined(__FreeBSD__)
+  printf("Platform: FreeBSD (_umtx_op supports exact K → kWakeAllThreshold = INT_MAX)\n");
 #elif defined(__APPLE__)
   printf("Platform: macOS\n");
 #elif defined(_WIN32)


### PR DESCRIPTION
# PR Details

This PR adds FreeBSD support to dispenso.

## Description

* **Wait/Wake Primitive Shim**:
  The wait/wake path in `dispenso/detail/notifier_common.h` is shimmed for FreeBSD using the
  native `_umtx_op` system call. `FUTEX_WAIT_PRIVATE` maps to `UMTX_OP_WAIT_UINT_PRIVATE`, and
  `FUTEX_WAKE_PRIVATE` maps to `UMTX_OP_WAKE_PRIVATE`, passing relative `CLOCK_MONOTONIC`
  timeouts through `struct _umtx_time`. Waking K threads uses `UMTX_OP_WAKE_PRIVATE`'s `val`
  parameter. The wait path zero-extends the 32-bit compare value, since the kernel compares the
  value at the futex address zero-extended against the full `u_long` val; sign extension would
  stop waits from sleeping once an epoch passes 2^31. This enables `EpochWaiter`,
  `CompletionEventImpl`, and `DISPENSO_WAKEUP_ENABLE` for FreeBSD, setting `kWakeAllThreshold`
  to `INT_MAX` (matching Linux) because native exact-K wakes require no loop-based fallback.

* **CpuSet Affinity**:
  For `CpuSet` (`dispenso/cpu_set.h`, `dispenso/cpu_set.cpp`), `currentHardwareThread()` uses
  `sched_getcpu()` on FreeBSD 13.1+ (returning -1 otherwise), and `availableCount()` queries
  the thread affinity mask via `cpuset_getaffinity()` + `CPU_COUNT`.

* **NUMA and Cache Topology Detection**:
  NUMA domains are read from the `vm.ndomains` sysctl, with each domain's CPU mask queried via
  `cpuset_getaffinity(CPU_LEVEL_WHICH, CPU_WHICH_DOMAIN, ...)`. L2/L3 cache sharing groups are
  parsed from the `kern.sched.topology_spec` sysctl. The parser is
  `detail::parseCacheGroupsFromTopologySpec`, a pure string helper built from two flat
  file-local helpers, with no platform guard, so its unit tests run on every platform.

* **Documentation**:
  Platform matrices updated (README, FAQ, getting started, CHANGELOG, cpu_set.h). FreeBSD
  thread-priority behavior documented in `priority.cpp` (kLow/kNormal/kHigh share
  `RTP_PRIO_NORMAL`, which the ULE scheduler recomputes). `bindCurrentThread()` notes that
  FreeBSD rejects masks containing nonexistent CPU ids with EINVAL where Linux intersects with
  the online CPUs.

* **Build/Test Warning Resolution**:
  Added a trailing comma to `TYPED_TEST_SUITE` calls in `concurrent_vector` tests to avoid
  Clang 19 zero-variadic macro warnings (`-Wc++20-extensions`) which are fatal under the
  build's `-Werror`.

## Related Issue

Part of #76. FreeBSD-specific tuning of `DISPENSO_TUNE_FIXED_SPIN_ITERS`,
`DISPENSO_TUNE_SPIN_CHECK_INTERVAL`, `DISPENSO_TUNE_WAKE_BRANCH_FACTOR`, and
`DISPENSO_TUNE_WAKE_GROUP_SIZE` is deferred; deriving meaningful values requires larger
FreeBSD hardware than was available (a 4-core VM).

## Motivation and Context

Enables compiling, running, and utilizing `dispenso` on FreeBSD with native wait/wake support,
CPU affinity queries, and cache-aware thread group construction from native topology
information.

## Test Plan

* **Unit Tests**:
  All 1,296 unit tests pass on FreeBSD 15.1-RELEASE (arm64, clang 19). The pre-existing
  flaky-labeled timing tests fail intermittently under parallel ctest and pass in isolation;
  L2 topology tests skip on hosts whose topology_spec reports only an L3 group. Extended the
  `CurrentHardwareThreadIsValid` test case in `tests/cpu_set_test.cpp` to cover FreeBSD, and
  added synthetic topology_spec tests covering nested, multi-socket, malformed, and
  defensive-branch inputs, taking the parser to full line coverage.
* **Sanitizers**:
  Full suite run under ASAN and TSAN on FreeBSD 15.1-RELEASE (arm64). ASAN: all tests pass.
  TSAN: the only reports are a known false positive in FreeBSD's uninstrumented system libthr
  during std::thread creation; with `race:libthr.so` suppressed, all affected tests pass, and
  no data races are reported in dispenso code.
* **API Verification**:
  Usage checked against the FreeBSD 15.1 system headers and man pages and the releng/15.1
  kernel source (`kern_umtx.c`, `kern_cpuset.c`), with native probes validating exact-K wake,
  timeout, privilege (EPERM), affinity (EINVAL), and compare-value semantics.
* **Performance Benchmarks**:
  Executed `wake_cost_bench`, `simple_pool_benchmark`, and `concurrent_vector_benchmark`
  inside of FreeBSD to measure wakeup latencies and queue scaling.

## Types of changes

- [x] Docs change
- [x] Refactoring
- [ ] Dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have run clang-format.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed, including in ASAN and TSAN modes (if available on your platform).